### PR TITLE
1.0.0b7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
   name        = 'PyOTA',
   description = 'IOTA API library for Python',
   url         = 'https://github.com/iotaledger/iota.lib.py',
-  version     = '1.0.0b6',
+  version     = '1.0.0b7',
 
   packages              = find_packages('src'),
   include_package_data  = True,

--- a/src/iota/adapter/wrappers.py
+++ b/src/iota/adapter/wrappers.py
@@ -16,7 +16,7 @@ __all__ = [
 ]
 
 
-class BaseWrapper(with_metaclass(ABCMeta)):
+class BaseWrapper(with_metaclass(ABCMeta, BaseAdapter)):
   """
   Base functionality for "adapter wrappers", used to extend the
   functionality of IOTA adapters.

--- a/src/iota/adapter/wrappers.py
+++ b/src/iota/adapter/wrappers.py
@@ -4,12 +4,15 @@ from __future__ import absolute_import, division, print_function, \
 
 from abc import ABCMeta, abstractmethod as abstract_method
 from logging import INFO, Logger
+from typing import Dict, Text
+
+from six import with_metaclass
 
 from iota.adapter import AdapterSpec, BaseAdapter, resolve_adapter
-from six import with_metaclass
 
 __all__ = [
   'LogWrapper',
+  'RoutingWrapper',
 ]
 
 
@@ -68,3 +71,69 @@ class LogWrapper(BaseWrapper):
     ))
 
     return response
+
+
+class RoutingWrapper(BaseWrapper):
+  """
+  Routes commands to different nodes.
+
+  This allows you to, for example, send POW requests to a local node,
+  while routing all other requests to a remote one.
+
+  Example::
+
+     # Route POW to localhost, everything else to 12.34.56.78.
+     iota = Iota(
+       RoutingWrapper('http://12.34.56.78:14265')
+         .add_route('attachToTangle', 'http://localhost:14265')
+         .add_route('interruptAttachingToTangle', 'http://localhost:14265')
+       ),
+     )
+  """
+  def __init__(self, default_adapter):
+    # type: (AdapterSpec) -> None
+    """
+    :param default_adapter:
+      Adapter to use for any routes not listed in ``routes``.
+    """
+    super(RoutingWrapper, self).__init__(default_adapter)
+
+    # Try to limit the number of distinct adapter instances we create
+    # when resolving URIs.
+    self.adapter_aliases = {} # type: Dict[AdapterSpec, BaseAdapter]
+
+    self.routes = {} # type: Dict[Text, BaseAdapter]
+
+  def add_route(self, command, adapter):
+    # type: (Text, AdapterSpec) -> RoutingWrapper
+    """
+    Adds a route to the wrapper.
+
+    :param command:
+      The name of the command to route (e.g., "attachToTangle").
+
+    :param adapter:
+      The adapter object or URI to route requests to.
+    """
+    if not isinstance(adapter, BaseAdapter):
+      try:
+        adapter = self.adapter_aliases[adapter]
+      except KeyError:
+        self.adapter_aliases[adapter] = adapter = resolve_adapter(adapter)
+
+    self.routes[command] = adapter
+
+    return self
+
+  def get_adapter(self, command):
+    # type: (Text) -> BaseAdapter
+    """
+    Return the adapter for the specified command.
+    """
+    return self.routes.get(command, self.adapter)
+
+  def send_request(self, payload, **kwargs):
+    # type: (dict, dict) -> dict
+    command = payload.get('command')
+
+    return self.get_adapter(command).send_request(payload, **kwargs)

--- a/src/iota/api.py
+++ b/src/iota/api.py
@@ -112,10 +112,10 @@ class StrictIota(object):
       min_weight_magnitude = self.default_min_weight_magnitude
 
     return self.attachToTangle(
-      trunk_transaction     = trunk_transaction,
-      branch_transaction    = branch_transaction,
-      min_weight_magnitude  = min_weight_magnitude,
-      trytes                = trytes,
+      trunkTransaction    = trunk_transaction,
+      branchTransaction   = branch_transaction,
+      minWeightMagnitude  = min_weight_magnitude,
+      trytes              = trytes,
     )
 
   def broadcast_transactions(self, trytes):
@@ -524,10 +524,10 @@ class Iota(StrictIota):
       - https://github.com/iotaledger/wiki/blob/master/api-proposal.md#gettransfers
     """
     return self.getTransfers(
-      seed              = self.seed,
-      start             = start,
-      stop              = stop,
-      inclusion_states  = inclusion_states,
+      seed            = self.seed,
+      start           = start,
+      stop            = stop,
+      inclusionStates = inclusion_states,
     )
 
   def prepare_transfer(self, transfers, inputs=None, change_address=None):
@@ -567,10 +567,10 @@ class Iota(StrictIota):
       - https://github.com/iotaledger/wiki/blob/master/api-proposal.md#preparetransfers
     """
     return self.prepareTransfer(
-      seed            = self.seed,
-      transfers       = transfers,
-      inputs          = inputs,
-      change_address  = change_address,
+      seed          = self.seed,
+      transfers     = transfers,
+      inputs        = inputs,
+      changeAddress = change_address,
     )
 
   def replay_bundle(
@@ -607,9 +607,9 @@ class Iota(StrictIota):
       min_weight_magnitude = self.default_min_weight_magnitude
 
     return self.replayBundle(
-      transaction           = transaction,
-      depth                 = depth,
-      min_weight_magnitude  = min_weight_magnitude,
+      transaction         = transaction,
+      depth               = depth,
+      minWeightMagnitude  = min_weight_magnitude,
     )
 
   def send_transfer(
@@ -659,12 +659,12 @@ class Iota(StrictIota):
       min_weight_magnitude = self.default_min_weight_magnitude
 
     return self.sendTransfer(
-      seed                  = self.seed,
-      depth                 = depth,
-      transfers             = transfers,
-      inputs                = inputs,
-      change_address        = change_address,
-      min_weight_magnitude  = min_weight_magnitude,
+      seed                = self.seed,
+      depth               = depth,
+      transfers           = transfers,
+      inputs              = inputs,
+      changeAddress       = change_address,
+      minWeightMagnitude  = min_weight_magnitude,
     )
 
   def send_trytes(self, trytes, depth, min_weight_magnitude=18):
@@ -690,7 +690,7 @@ class Iota(StrictIota):
       - https://github.com/iotaledger/wiki/blob/master/api-proposal.md#sendtrytes
     """
     return self.sendTrytes(
-      trytes                = trytes,
-      depth                 = depth,
-      min_weight_magnitude  = min_weight_magnitude,
+      trytes              = trytes,
+      depth               = depth,
+      minWeightMagnitude  = min_weight_magnitude,
     )

--- a/src/iota/commands/core/attach_to_tangle.py
+++ b/src/iota/commands/core/attach_to_tangle.py
@@ -47,5 +47,9 @@ class AttachToTangleRequestFilter(RequestFilter):
 class AttachToTangleResponseFilter(ResponseFilter):
   def __init__(self):
     super(AttachToTangleResponseFilter, self).__init__({
-      'trytes': f.FilterRepeater(f.ByteString(encoding='ascii') | Trytes),
+      'trytes':
+        f.FilterRepeater(
+            f.ByteString(encoding='ascii')
+          | Trytes(result_type=TransactionTrytes)
+        ),
     })

--- a/src/iota/commands/core/attach_to_tangle.py
+++ b/src/iota/commands/core/attach_to_tangle.py
@@ -30,8 +30,8 @@ class AttachToTangleCommand(FilterCommand):
 class AttachToTangleRequestFilter(RequestFilter):
   def __init__(self):
     super(AttachToTangleRequestFilter, self).__init__({
-      'branch_transaction': f.Required | Trytes(result_type=TransactionHash),
-      'trunk_transaction':  f.Required | Trytes(result_type=TransactionHash),
+      'branchTransaction': f.Required | Trytes(result_type=TransactionHash),
+      'trunkTransaction':  f.Required | Trytes(result_type=TransactionHash),
 
       'trytes':
           f.Required
@@ -40,7 +40,7 @@ class AttachToTangleRequestFilter(RequestFilter):
 
       # Loosely-validated; testnet nodes require a different value than
       # mainnet.
-      'min_weight_magnitude': f.Required| f.Type(int) | f.Min(1),
+      'minWeightMagnitude': f.Required| f.Type(int) | f.Min(1),
     })
 
 

--- a/src/iota/commands/core/broadcast_transactions.py
+++ b/src/iota/commands/core/broadcast_transactions.py
@@ -3,8 +3,9 @@ from __future__ import absolute_import, division, print_function, \
   unicode_literals
 
 import filters as f
+
 from iota import TransactionTrytes
-from iota.commands import FilterCommand, RequestFilter, ResponseFilter
+from iota.commands import FilterCommand, RequestFilter
 from iota.filters import Trytes
 
 __all__ = [
@@ -24,7 +25,7 @@ class BroadcastTransactionsCommand(FilterCommand):
     return BroadcastTransactionsRequestFilter()
 
   def get_response_filter(self):
-    return BroadcastTransactionsResponseFilter()
+    pass
 
 
 class BroadcastTransactionsRequestFilter(RequestFilter):
@@ -34,11 +35,4 @@ class BroadcastTransactionsRequestFilter(RequestFilter):
           f.Required
         | f.Array
         | f.FilterRepeater(f.Required | Trytes(result_type=TransactionTrytes)),
-    })
-
-
-class BroadcastTransactionsResponseFilter(ResponseFilter):
-  def __init__(self):
-    super(BroadcastTransactionsResponseFilter, self).__init__({
-      'trytes': f.FilterRepeater(f.ByteString(encoding='ascii') | Trytes),
     })

--- a/src/iota/commands/extended/broadcast_and_store.py
+++ b/src/iota/commands/extended/broadcast_and_store.py
@@ -28,4 +28,7 @@ class BroadcastAndStoreCommand(FilterCommand):
 
   def _execute(self, request):
     BroadcastTransactionsCommand(self.adapter)(**request)
-    return StoreTransactionsCommand(self.adapter)(**request)
+    StoreTransactionsCommand(self.adapter)(**request)
+    return {
+      'trytes': request['trytes'],
+    }

--- a/src/iota/commands/extended/get_transfers.py
+++ b/src/iota/commands/extended/get_transfers.py
@@ -37,7 +37,7 @@ class GetTransfersCommand(FilterCommand):
 
   def _execute(self, request):
     stop              = request['stop'] # type: Optional[int]
-    inclusion_states  = request['inclusion_states'] # type: bool
+    inclusion_states  = request['inclusionStates'] # type: bool
     seed              = request['seed'] # type: Seed
     start             = request['start'] # type: int
 
@@ -165,12 +165,12 @@ class GetTransfersRequestFilter(RequestFilter):
         'stop':   f.Type(int) | f.Min(0),
         'start':  f.Type(int) | f.Min(0) | f.Optional(0),
 
-        'inclusion_states': f.Type(bool) | f.Optional(False),
+        'inclusionStates': f.Type(bool) | f.Optional(False),
       },
 
       allow_missing_keys = {
         'stop',
-        'inclusion_states',
+        'inclusionStates',
         'start',
       },
     )

--- a/src/iota/commands/extended/prepare_transfer.py
+++ b/src/iota/commands/extended/prepare_transfer.py
@@ -41,7 +41,7 @@ class PrepareTransferCommand(FilterCommand):
     bundle    = ProposedBundle(request['transfers'])
 
     # Optional parameters.
-    change_address  = request.get('change_address') # type: Optional[Address]
+    change_address  = request.get('changeAddress') # type: Optional[Address]
     proposed_inputs = request.get('inputs') # type: Optional[List[Address]]
 
     want_to_spend = bundle.balance
@@ -131,7 +131,7 @@ class PrepareTransferRequestFilter(RequestFilter):
         ),
 
         # Optional parameters.
-        'change_address': Trytes(result_type=Address),
+        'changeAddress': Trytes(result_type=Address),
 
         # Note that ``inputs`` is allowed to be an empty array.
         'inputs':
@@ -139,7 +139,7 @@ class PrepareTransferRequestFilter(RequestFilter):
       },
 
       allow_missing_keys = {
-        'change_address',
+        'changeAddress',
         'inputs',
       },
     )

--- a/src/iota/commands/extended/replay_bundle.py
+++ b/src/iota/commands/extended/replay_bundle.py
@@ -33,7 +33,7 @@ class ReplayBundleCommand(FilterCommand):
 
   def _execute(self, request):
     depth                 = request['depth'] # type: int
-    min_weight_magnitude  = request['min_weight_magnitude'] # type: int
+    min_weight_magnitude  = request['minWeightMagnitude'] # type: int
     transaction           = request['transaction'] # type: TransactionHash
 
     gb_response = GetBundlesCommand(self.adapter)(transaction=transaction)
@@ -43,8 +43,8 @@ class ReplayBundleCommand(FilterCommand):
     bundle = gb_response['bundles'][0] # type: Bundle
 
     return SendTrytesCommand(self.adapter)(
-      depth                 = depth,
-      min_weight_magnitude  = min_weight_magnitude,
+      depth               = depth,
+      minWeightMagnitude  = min_weight_magnitude,
 
 
       trytes = bundle.as_tryte_strings(head_to_tail=True),
@@ -59,5 +59,5 @@ class ReplayBundleRequestFilter(RequestFilter):
 
       # Loosely-validated; testnet nodes require a different value than
       # mainnet.
-      'min_weight_magnitude': f.Required | f.Type(int) | f.Min(1),
+      'minWeightMagnitude': f.Required | f.Type(int) | f.Min(1),
     })

--- a/src/iota/commands/extended/send_transfer.py
+++ b/src/iota/commands/extended/send_transfer.py
@@ -32,24 +32,24 @@ class SendTransferCommand(FilterCommand):
     pass
 
   def _execute(self, request):
-    change_address        = request['change_address'] # type: Optional[Address]
+    change_address        = request['changeAddress'] # type: Optional[Address]
     depth                 = request['depth'] # type: int
     inputs                = request['inputs'] or [] # type: List[Address]
-    min_weight_magnitude  = request['min_weight_magnitude'] # type: int
+    min_weight_magnitude  = request['minWeightMagnitude'] # type: int
     seed                  = request['seed'] # type: Seed
     transfers             = request['transfers'] # type: List[ProposedTransaction]
 
     pt_response = PrepareTransferCommand(self.adapter)(
-      change_address  = change_address,
+      changeAddress   = change_address,
       inputs          = inputs,
       seed            = seed,
       transfers       = transfers,
     )
 
     st_response = SendTrytesCommand(self.adapter)(
-      depth                 = depth,
-      min_weight_magnitude  = min_weight_magnitude,
-      trytes                = pt_response['trytes'],
+      depth               = depth,
+      minWeightMagnitude  = min_weight_magnitude,
+      trytes              = pt_response['trytes'],
     )
 
     return {
@@ -67,7 +67,7 @@ class SendTransferRequestFilter(RequestFilter):
 
         # Loosely-validated; testnet nodes require a different value
         # than mainnet.
-        'min_weight_magnitude': f.Required | f.Type(int) | f.Min(1),
+        'minWeightMagnitude': f.Required | f.Type(int) | f.Min(1),
 
         'transfers': (
             f.Required
@@ -76,7 +76,7 @@ class SendTransferRequestFilter(RequestFilter):
         ),
 
         # Optional parameters.
-        'change_address': Trytes(result_type=Address),
+        'changeAddress': Trytes(result_type=Address),
 
 
         # Note that ``inputs`` is allowed to be an empty array.
@@ -85,7 +85,7 @@ class SendTransferRequestFilter(RequestFilter):
       },
 
       allow_missing_keys = {
-        'change_address',
+        'changeAddress',
         'inputs',
       },
     )

--- a/src/iota/commands/extended/send_trytes.py
+++ b/src/iota/commands/extended/send_trytes.py
@@ -34,7 +34,7 @@ class SendTrytesCommand(FilterCommand):
 
   def _execute(self, request):
     depth                 = request['depth'] # type: int
-    min_weight_magnitude  = request['min_weight_magnitude'] # type: int
+    min_weight_magnitude  = request['minWeightMagnitude'] # type: int
     trytes                = request['trytes'] # type: List[TryteString]
 
     # Call ``getTransactionsToApprove`` to locate trunk and branch
@@ -42,11 +42,11 @@ class SendTrytesCommand(FilterCommand):
     gta_response = GetTransactionsToApproveCommand(self.adapter)(depth=depth)
 
     AttachToTangleCommand(self.adapter)(
-      branch_transaction  = gta_response.get('branchTransaction'),
-      trunk_transaction   = gta_response.get('trunkTransaction'),
+      branchTransaction   = gta_response.get('branchTransaction'),
+      trunkTransaction    = gta_response.get('trunkTransaction'),
 
-      min_weight_magnitude  = min_weight_magnitude,
-      trytes                = trytes,
+      minWeightMagnitude  = min_weight_magnitude,
+      trytes              = trytes,
     )
 
     return BroadcastAndStoreCommand(self.adapter)(trytes=request['trytes'])
@@ -64,5 +64,5 @@ class SendTrytesRequestFilter(RequestFilter):
 
       # Loosely-validated; testnet nodes require a different value than
       # mainnet.
-      'min_weight_magnitude': f.Required | f.Type(int) | f.Min(1),
+      'minWeightMagnitude': f.Required | f.Type(int) | f.Min(1),
     })

--- a/src/iota/commands/extended/send_trytes.py
+++ b/src/iota/commands/extended/send_trytes.py
@@ -41,7 +41,7 @@ class SendTrytesCommand(FilterCommand):
     # transactions so that we can attach the bundle to the Tangle.
     gta_response = GetTransactionsToApproveCommand(self.adapter)(depth=depth)
 
-    AttachToTangleCommand(self.adapter)(
+    att_response = AttachToTangleCommand(self.adapter)(
       branchTransaction   = gta_response.get('branchTransaction'),
       trunkTransaction    = gta_response.get('trunkTransaction'),
 
@@ -50,7 +50,7 @@ class SendTrytesCommand(FilterCommand):
     )
 
     # ``trytes`` now have POW!
-    trytes = request['trytes']
+    trytes = att_response['trytes']
 
     BroadcastAndStoreCommand(self.adapter)(trytes=trytes)
 

--- a/src/iota/commands/extended/send_trytes.py
+++ b/src/iota/commands/extended/send_trytes.py
@@ -49,7 +49,14 @@ class SendTrytesCommand(FilterCommand):
       trytes              = trytes,
     )
 
-    return BroadcastAndStoreCommand(self.adapter)(trytes=request['trytes'])
+    # ``trytes`` now have POW!
+    trytes = request['trytes']
+
+    BroadcastAndStoreCommand(self.adapter)(trytes=trytes)
+
+    return {
+      'trytes': trytes,
+    }
 
 
 class SendTrytesRequestFilter(RequestFilter):

--- a/test/adapter/__init__.py
+++ b/test/adapter/__init__.py
@@ -1,0 +1,3 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, \
+  unicode_literals

--- a/test/adapter/wrappers_test.py
+++ b/test/adapter/wrappers_test.py
@@ -1,0 +1,92 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, \
+  unicode_literals
+
+from unittest import TestCase
+
+from iota.adapter import HttpAdapter, MockAdapter
+from iota.adapter.wrappers import RoutingWrapper
+
+
+class RoutingWrapperTestCase(TestCase):
+  def test_routing(self):
+    """
+    Routing commands to different adapters.
+    """
+    default_adapter = MockAdapter()
+    pow_adapter     = MockAdapter()
+
+    wrapper = (
+      RoutingWrapper(default_adapter)
+        .add_route('attachToTangle', pow_adapter)
+        .add_route('interruptAttachingToTangle', pow_adapter)
+    )
+
+    default_adapter.seed_response('getNodeInfo', {'id': 'default1'})
+    pow_adapter.seed_response('attachToTangle', {'id': 'pow1'})
+    pow_adapter.seed_response('interruptAttachingToTangle', {'id': 'pow2'})
+
+    self.assertDictEqual(
+      wrapper.send_request({'command': 'attachToTangle'}),
+      {'id': 'pow1'},
+    )
+
+    self.assertDictEqual(
+      wrapper.send_request({'command': 'interruptAttachingToTangle'}),
+      {'id': 'pow2'},
+    )
+
+    # Any commands that aren't routed go to the default adapter.
+    self.assertDictEqual(
+      wrapper.send_request({'command': 'getNodeInfo'}),
+      {'id': 'default1'},
+    )
+
+  def test_router_aliasing(self):
+    """
+    The router will try to re-use existing adapter instances.
+    """
+    wrapper1 = RoutingWrapper('http://localhost:14265')
+    adapter_default = wrapper1.adapter
+
+    # The router will try to minimize the number of adapter instances
+    # that it creates from URIs.
+    wrapper1\
+      .add_route('alpha', 'http://localhost:14265')\
+      .add_route('bravo', 'http://localhost:14265')\
+
+    # Two routes with the same URI => same adapter instance.
+    self.assertIs(
+      wrapper1.get_adapter('bravo'),
+      wrapper1.get_adapter('alpha'),
+    )
+
+    # "127.0.0.1" != "localhost", so separate adapters created.
+    wrapper1.add_route('charlie', 'http://127.0.0.1:14265')
+    self.assertIsNot(
+      wrapper1.get_adapter('charlie'),
+      wrapper1.get_adapter('alpha'),
+    )
+
+    # Providing an adapter instance bypasses the whole setup.
+    wrapper1.add_route('delta', HttpAdapter('localhost', 14265))
+    self.assertIsNot(
+      wrapper1.get_adapter('delta'),
+      wrapper1.get_adapter('alpha'),
+    )
+
+    # The default adapter is always kept separate, even if it URI
+    # matches a routing adapter.
+    self.assertIsNot(
+      wrapper1.get_adapter('foo'),
+      wrapper1.get_adapter('alpha'),
+    )
+
+    # Aliased adapters are not shared between routers.
+    wrapper2 = RoutingWrapper(adapter_default)
+
+    wrapper2.add_route('echo', 'http://localhost:14265')
+    self.assertIsNot(
+      wrapper2.get_adapter('echo'),
+      wrapper1.get_adapter('alpha'),
+    )

--- a/test/commands/core/attach_to_tangle_test.py
+++ b/test/commands/core/attach_to_tangle_test.py
@@ -413,8 +413,8 @@ class AttachToTangleResponseFilterTestCase(BaseFilterTestCase):
 
       {
         'trytes': [
-          TryteString(self.trytes1),
-          TryteString(self.trytes2),
+          TransactionTrytes(self.trytes1),
+          TransactionTrytes(self.trytes2),
         ],
 
         'duration': 42,

--- a/test/commands/core/attach_to_tangle_test.py
+++ b/test/commands/core/attach_to_tangle_test.py
@@ -37,9 +37,9 @@ class AttachToTangleRequestFilterTestCase(BaseFilterTestCase):
     The incoming request is valid.
     """
     request = {
-      'trunk_transaction':    TransactionHash(self.txn_id),
-      'branch_transaction':   TransactionHash(self.txn_id),
-      'min_weight_magnitude': 20,
+      'trunkTransaction':   TransactionHash(self.txn_id),
+      'branchTransaction':  TransactionHash(self.txn_id),
+      'minWeightMagnitude': 20,
 
       'trytes':               [
         TransactionTrytes(self.trytes1),
@@ -59,9 +59,9 @@ class AttachToTangleRequestFilterTestCase(BaseFilterTestCase):
     """
     filter_ = self._filter({
       # Any value that can be converted into a TransactionHash is valid
-      #   here.
-      'trunk_transaction':    binary_type(self.txn_id),
-      'branch_transaction':   bytearray(self.txn_id),
+      # here.
+      'trunkTransaction':   binary_type(self.txn_id),
+      'branchTransaction':  bytearray(self.txn_id),
 
       'trytes': [
         # ``trytes`` can contain any value that can be converted into a
@@ -75,7 +75,7 @@ class AttachToTangleRequestFilterTestCase(BaseFilterTestCase):
       ],
 
       # This still has to be an int, however.
-      'min_weight_magnitude': 30,
+      'minWeightMagnitude': 30,
     })
 
     self.assertFilterPasses(filter_)
@@ -85,9 +85,9 @@ class AttachToTangleRequestFilterTestCase(BaseFilterTestCase):
       # After running through the filter, all of the values have been
       # converted to the correct types.
       {
-        'trunk_transaction':    TransactionHash(self.txn_id),
-        'branch_transaction':   TransactionHash(self.txn_id),
-        'min_weight_magnitude': 30,
+        'trunkTransaction':   TransactionHash(self.txn_id),
+        'branchTransaction':  TransactionHash(self.txn_id),
+        'minWeightMagnitude': 30,
 
         'trytes':               [
           TransactionTrytes(self.trytes1),
@@ -108,10 +108,10 @@ class AttachToTangleRequestFilterTestCase(BaseFilterTestCase):
       {},
 
       {
-        'branch_transaction':   [f.FilterMapper.CODE_MISSING_KEY],
-        'min_weight_magnitude': [f.FilterMapper.CODE_MISSING_KEY],
-        'trunk_transaction':    [f.FilterMapper.CODE_MISSING_KEY],
-        'trytes':               [f.FilterMapper.CODE_MISSING_KEY],
+        'branchTransaction':  [f.FilterMapper.CODE_MISSING_KEY],
+        'minWeightMagnitude': [f.FilterMapper.CODE_MISSING_KEY],
+        'trunkTransaction':   [f.FilterMapper.CODE_MISSING_KEY],
+        'trytes':             [f.FilterMapper.CODE_MISSING_KEY],
       },
     )
 
@@ -121,10 +121,10 @@ class AttachToTangleRequestFilterTestCase(BaseFilterTestCase):
     """
     self.assertFilterErrors(
       {
-        'branch_transaction':   TransactionHash(self.txn_id),
-        'min_weight_magnitude': 20,
-        'trunk_transaction':    TransactionHash(self.txn_id),
-        'trytes':               [TryteString(self.trytes1)],
+        'branchTransaction':  TransactionHash(self.txn_id),
+        'minWeightMagnitude': 20,
+        'trunkTransaction':   TransactionHash(self.txn_id),
+        'trytes':             [TryteString(self.trytes1)],
 
         # Hey, how'd that get in there?
         'foo': 'bar',
@@ -137,149 +137,149 @@ class AttachToTangleRequestFilterTestCase(BaseFilterTestCase):
 
   def test_fail_trunk_transaction_null(self):
     """
-    ``trunk_transaction`` is null.
+    ``trunkTransaction`` is null.
     """
     self.assertFilterErrors(
       {
-        'trunk_transaction':  None,
+        'trunkTransaction':  None,
 
-        'branch_transaction':   TransactionHash(self.txn_id),
-        'min_weight_magnitude': 13,
-        'trytes':               [TryteString(self.trytes1)],
+        'branchTransaction':  TransactionHash(self.txn_id),
+        'minWeightMagnitude': 13,
+        'trytes':             [TryteString(self.trytes1)],
       },
 
       {
-        'trunk_transaction': [f.Required.CODE_EMPTY],
+        'trunkTransaction': [f.Required.CODE_EMPTY],
       },
     )
 
   def test_fail_trunk_transaction_wrong_type(self):
     """
-    ``trunk_transaction`` can't be converted to a TryteString.
+    ``trunkTransaction`` can't be converted to a TryteString.
     """
     self.assertFilterErrors(
       {
-        # Strings are not valid tryte sequences.
-        'trunk_transaction':  text_type(self.txn_id, 'ascii'),
+        # Unicode strings are not valid tryte sequences.
+        'trunkTransaction':  text_type(self.txn_id, 'ascii'),
 
-        'branch_transaction':   TransactionHash(self.txn_id),
-        'min_weight_magnitude': 13,
-        'trytes':               [TryteString(self.trytes1)],
+        'branchTransaction':  TransactionHash(self.txn_id),
+        'minWeightMagnitude': 13,
+        'trytes':             [TryteString(self.trytes1)],
       },
 
       {
-        'trunk_transaction': [f.Type.CODE_WRONG_TYPE],
+        'trunkTransaction': [f.Type.CODE_WRONG_TYPE],
       },
     )
 
   def test_fail_branch_transaction_null(self):
     """
-    ``branch_transaction`` is null.
+    ``branchTransaction`` is null.
     """
     self.assertFilterErrors(
       {
-        'branch_transaction': None,
+        'branchTransaction': None,
 
-        'min_weight_magnitude': 13,
-        'trunk_transaction':    TransactionHash(self.txn_id),
-        'trytes':               [TryteString(self.trytes1)],
+        'minWeightMagnitude': 13,
+        'trunkTransaction':   TransactionHash(self.txn_id),
+        'trytes':             [TryteString(self.trytes1)],
       },
 
       {
-        'branch_transaction': [f.Required.CODE_EMPTY],
+        'branchTransaction': [f.Required.CODE_EMPTY],
       },
     )
 
   def test_fail_branch_transaction_wrong_type(self):
     """
-    ``branch_transaction`` can't be converted to a TryteString.
+    ``branchTransaction`` can't be converted to a TryteString.
     """
     self.assertFilterErrors(
       {
         # Strings are not valid tryte sequences.
-        'branch_transaction': text_type(self.txn_id, 'ascii'),
+        'branchTransaction': text_type(self.txn_id, 'ascii'),
 
-        'min_weight_magnitude': 13,
-        'trunk_transaction':    TransactionHash(self.txn_id),
-        'trytes':               [TryteString(self.trytes1)],
+        'minWeightMagnitude': 13,
+        'trunkTransaction':   TransactionHash(self.txn_id),
+        'trytes':             [TryteString(self.trytes1)],
       },
 
       {
-        'branch_transaction': [f.Type.CODE_WRONG_TYPE],
+        'branchTransaction': [f.Type.CODE_WRONG_TYPE],
       },
     )
 
   def test_fail_min_weight_magnitude_null(self):
     """
-    ``min_weight_magnitude`` is null.
+    ``minWeightMagnitude`` is null.
     """
     self.assertFilterErrors(
       {
-        'min_weight_magnitude': None,
+        'minWeightMagnitude': None,
 
-        'branch_transaction': TransactionHash(self.txn_id),
-        'trunk_transaction':  TransactionHash(self.txn_id),
+        'branchTransaction':  TransactionHash(self.txn_id),
+        'trunkTransaction':   TransactionHash(self.txn_id),
         'trytes':             [TryteString(self.trytes1)],
       },
 
       {
-        'min_weight_magnitude': [f.Required.CODE_EMPTY],
+        'minWeightMagnitude': [f.Required.CODE_EMPTY],
       },
     )
 
   def test_fail_min_weight_magnitude_float(self):
     """
-    ``min_weight_magnitude`` is a float.
+    ``minWeightMagnitude`` is a float.
     """
     self.assertFilterErrors(
       {
         # I don't care if the fpart is empty; it's still not an int!
-        'min_weight_magnitude': 20.0,
+        'minWeightMagnitude': 20.0,
 
-        'branch_transaction': TransactionHash(self.txn_id),
-        'trunk_transaction':  TransactionHash(self.txn_id),
+        'branchTransaction':  TransactionHash(self.txn_id),
+        'trunkTransaction':   TransactionHash(self.txn_id),
         'trytes':             [TryteString(self.trytes1)],
       },
 
       {
-        'min_weight_magnitude': [f.Type.CODE_WRONG_TYPE],
+        'minWeightMagnitude': [f.Type.CODE_WRONG_TYPE],
       },
     )
 
   def test_fail_min_weight_magnitude_string(self):
     """
-    ``min_weight_magnitude`` is a string.
+    ``minWeightMagnitude`` is a string.
     """
     self.assertFilterErrors(
       {
         # For want of an int cast, the transaction was lost.
-        'min_weight_magnitude': '20',
+        'minWeightMagnitude': '20',
 
-        'branch_transaction': TransactionHash(self.txn_id),
-        'trunk_transaction':  TransactionHash(self.txn_id),
+        'branchTransaction':  TransactionHash(self.txn_id),
+        'trunkTransaction':   TransactionHash(self.txn_id),
         'trytes':             [TryteString(self.trytes1)],
       },
 
       {
-        'min_weight_magnitude': [f.Type.CODE_WRONG_TYPE],
+        'minWeightMagnitude': [f.Type.CODE_WRONG_TYPE],
       },
     )
 
   def test_fail_min_weight_magnitude_too_small(self):
     """
-    ``min_weight_magnitude`` is less than 1.
+    ``minWeightMagnitude`` is less than 1.
     """
     self.assertFilterErrors(
       {
-        'min_weight_magnitude': 0,
+        'minWeightMagnitude': 0,
 
-        'branch_transaction': TransactionHash(self.txn_id),
-        'trunk_transaction':  TransactionHash(self.txn_id),
+        'branchTransaction':  TransactionHash(self.txn_id),
+        'trunkTransaction':   TransactionHash(self.txn_id),
         'trytes':             [TryteString(self.trytes1)],
       },
 
       {
-        'min_weight_magnitude': [f.Min.CODE_TOO_SMALL],
+        'minWeightMagnitude': [f.Min.CODE_TOO_SMALL],
       },
     )
 
@@ -291,9 +291,9 @@ class AttachToTangleRequestFilterTestCase(BaseFilterTestCase):
       {
         'trytes': None,
 
-        'branch_transaction':   TransactionHash(self.txn_id),
-        'min_weight_magnitude': 13,
-        'trunk_transaction':    TransactionHash(self.txn_id),
+        'branchTransaction':  TransactionHash(self.txn_id),
+        'minWeightMagnitude': 13,
+        'trunkTransaction':   TransactionHash(self.txn_id),
       },
 
       {
@@ -311,9 +311,9 @@ class AttachToTangleRequestFilterTestCase(BaseFilterTestCase):
         # a single tryte sequence.
         'trytes': TryteString(self.trytes1),
 
-        'branch_transaction':   TransactionHash(self.txn_id),
-        'min_weight_magnitude': 13,
-        'trunk_transaction':    TransactionHash(self.txn_id),
+        'branchTransaction':  TransactionHash(self.txn_id),
+        'minWeightMagnitude': 13,
+        'trunkTransaction':   TransactionHash(self.txn_id),
       },
 
       {
@@ -331,9 +331,9 @@ class AttachToTangleRequestFilterTestCase(BaseFilterTestCase):
         # inside it.
         'trytes': [],
 
-        'branch_transaction':   TransactionHash(self.txn_id),
-        'min_weight_magnitude': 13,
-        'trunk_transaction':    TransactionHash(self.txn_id),
+        'branchTransaction':  TransactionHash(self.txn_id),
+        'minWeightMagnitude': 13,
+        'trunkTransaction':   TransactionHash(self.txn_id),
       },
 
       {
@@ -363,9 +363,9 @@ class AttachToTangleRequestFilterTestCase(BaseFilterTestCase):
           b'9' * (TransactionTrytes.LEN + 1),
         ],
 
-        'branch_transaction':   TransactionHash(self.txn_id),
-        'min_weight_magnitude': 13,
-        'trunk_transaction':    TransactionHash(self.txn_id),
+        'branchTransaction':  TransactionHash(self.txn_id),
+        'minWeightMagnitude': 13,
+        'trunkTransaction':   TransactionHash(self.txn_id),
       },
 
       {

--- a/test/commands/core/broadcast_transactions_test.py
+++ b/test/commands/core/broadcast_transactions_test.py
@@ -178,46 +178,6 @@ class BroadcastTransactionsRequestFilterTestCase(BaseFilterTestCase):
     )
 
 
-class BroadcastTransactionsResponseFilterTestCase(BaseFilterTestCase):
-  filter_type = BroadcastTransactionsCommand(MockAdapter()).get_response_filter
-  skip_value_check = True
-
-  # noinspection SpellCheckingInspection
-  def setUp(self):
-    super(BroadcastTransactionsResponseFilterTestCase, self).setUp()
-
-    # Define a few valid values here that we can reuse across multiple
-    # tests.
-    self.trytes1 = b'RBTC9D9DCDQAEASBYBCCKBFA'
-    self.trytes2 =\
-      b'CCPCBDVC9DTCEAKDXC9D9DEARCWCPCBDVCTCEAHDWCTCEAKDCDFD9DSCSA'
-
-  def test_pass_happy_path(self):
-    """
-    The incoming response contains valid values.
-    """
-    # Responses from the node arrive as strings.
-    filter_ = self._filter({
-      'trytes': [
-        text_type(self.trytes1, 'ascii'),
-        text_type(self.trytes2, 'ascii'),
-      ],
-    })
-
-    self.assertFilterPasses(filter_)
-
-    self.assertDictEqual(
-      filter_.cleaned_data,
-
-      {
-        'trytes': [
-          TryteString(self.trytes1),
-          TryteString(self.trytes2),
-        ],
-      },
-    )
-
-
 class BroadcastTransactionsCommandTestCase(TestCase):
   def setUp(self):
     super(BroadcastTransactionsCommandTestCase, self).setUp()

--- a/test/commands/extended/broadcast_and_store_test.py
+++ b/test/commands/extended/broadcast_and_store_test.py
@@ -4,10 +4,11 @@ from __future__ import absolute_import, division, print_function, \
 
 from unittest import TestCase
 
-from iota import BadApiResponse, Iota, TransactionTrytes, TryteString
+from six import text_type
+
+from iota import Iota, TransactionTrytes
 from iota.adapter import MockAdapter
 from iota.commands.extended.broadcast_and_store import BroadcastAndStoreCommand
-from six import text_type
 
 
 class BroadcastAndStoreCommandTestCase(TestCase):
@@ -50,77 +51,4 @@ class BroadcastAndStoreCommandTestCase(TestCase):
 
     response = self.command(trytes=trytes)
 
-    self.assertDictEqual(response, {})
-
-    self.assertListEqual(
-      self.adapter.requests,
-
-      [
-        {
-          'command':  'broadcastTransactions',
-          'trytes':   trytes,
-        },
-
-        {
-          'command':  'storeTransactions',
-          'trytes':   trytes,
-        },
-      ],
-    )
-
-  def test_broadcast_transactions_fails(self):
-    """
-    The `broadcastTransactions`` command fails.
-    """
-    self.adapter.seed_response('broadcastTransactions', {
-      'error': "I'm a teapot.",
-    })
-
-    with self.assertRaises(BadApiResponse):
-      self.command(trytes=[TransactionTrytes(self.trytes1)])
-
-    # The command stopped after the first request failed.
-    self.assertListEqual(
-      self.adapter.requests,
-
-      [{
-        'command':  'broadcastTransactions',
-        'trytes':   [TransactionTrytes(self.trytes1)],
-      }],
-    )
-
-  def test_store_transactions_fails(self):
-    """
-    The ``storeTransactions`` command fails.
-    """
-    self.adapter.seed_response('broadcastTransactions', {
-      'trytes': [
-        text_type(self.trytes1, 'ascii'),
-        text_type(self.trytes2, 'ascii'),
-      ],
-    })
-
-    self.adapter.seed_response('storeTransactions', {
-      'error': "I'm a teapot.",
-    })
-
-    with self.assertRaises(BadApiResponse):
-      self.command(trytes=[TransactionTrytes(self.trytes1)])
-
-    # The `broadcastTransactions` command was still executed; there is
-    # no way to execute these commands atomically.
-    self.assertListEqual(
-      self.adapter.requests,
-
-      [
-        {
-          'command':  'broadcastTransactions',
-          'trytes':   [TransactionTrytes(self.trytes1)],
-        },
-
-        {
-          'command':  'storeTransactions',
-          'trytes':   [TransactionTrytes(self.trytes1)],
-        },
-      ],
-    )
+    self.assertDictEqual(response, {'trytes': trytes})

--- a/test/commands/extended/get_transfers_test.py
+++ b/test/commands/extended/get_transfers_test.py
@@ -35,7 +35,7 @@ class GetTransfersRequestFilterTestCase(BaseFilterTestCase):
       'seed':             Seed(self.seed),
       'start':            0,
       'stop':             10,
-      'inclusion_states': True,
+      'inclusionStates':  True,
     }
 
     filter_ = self._filter(request)
@@ -56,7 +56,7 @@ class GetTransfersRequestFilterTestCase(BaseFilterTestCase):
       # These values must still be integers/bools, however.
       'start':            42,
       'stop':             86,
-      'inclusion_states': True,
+      'inclusionStates':  True,
     })
 
     self.assertFilterPasses(filter_)
@@ -67,7 +67,7 @@ class GetTransfersRequestFilterTestCase(BaseFilterTestCase):
         'seed':             Seed(self.seed),
         'start':            42,
         'stop':             86,
-        'inclusion_states': True,
+        'inclusionStates':  True,
       },
     )
 
@@ -87,7 +87,7 @@ class GetTransfersRequestFilterTestCase(BaseFilterTestCase):
         'seed':             Seed(self.seed),
         'start':            0,
         'stop':             None,
-        'inclusion_states': False,
+        'inclusionStates':  False,
       }
     )
 
@@ -300,17 +300,17 @@ class GetTransfersRequestFilterTestCase(BaseFilterTestCase):
 
   def test_fail_inclusion_states_wrong_type(self):
     """
-    ``inclusion_states`` is not a boolean.
+    ``inclusionStates`` is not a boolean.
     """
     self.assertFilterErrors(
       {
-        'inclusion_states': '1',
+        'inclusionStates': '1',
 
         'seed': Seed(self.seed),
       },
 
       {
-        'inclusion_states': [f.Type.CODE_WRONG_TYPE],
+        'inclusionStates': [f.Type.CODE_WRONG_TYPE],
       },
     )
 
@@ -731,7 +731,7 @@ class GetTransfersCommandTestCase(TestCase):
           response = self.command(
             seed = Seed.random(),
 
-            inclusion_states = True,
+            inclusionStates = True,
 
             # To keep the test focused, only retrieve a single
             # transaction.

--- a/test/commands/extended/prepare_transfer_test.py
+++ b/test/commands/extended/prepare_transfer_test.py
@@ -75,7 +75,7 @@ class PrepareTransferRequestFilterTestCase(BaseFilterTestCase):
     Request is valid.
     """
     request = {
-      'change_address': Address(self.trytes1),
+      'changeAddress':  Address(self.trytes1),
       'seed':           Seed(self.trytes2),
       'transfers':      [self.transfer1, self.transfer2],
 
@@ -98,7 +98,7 @@ class PrepareTransferRequestFilterTestCase(BaseFilterTestCase):
     """
     filter_ = self._filter({
       # Any TrytesCompatible value works here.
-      'change_address': binary_type(self.trytes1),
+      'changeAddress':  binary_type(self.trytes1),
       'seed':           bytearray(self.trytes2),
 
       # These have to be :py:class:`Address` instances, so that we can
@@ -117,7 +117,7 @@ class PrepareTransferRequestFilterTestCase(BaseFilterTestCase):
       filter_.cleaned_data,
 
       {
-        'change_address': Address(self.trytes1),
+        'changeAddress':  Address(self.trytes1),
         'seed':           Seed(self.trytes2),
         'transfers':      [self.transfer1, self.transfer2],
 
@@ -146,7 +146,7 @@ class PrepareTransferRequestFilterTestCase(BaseFilterTestCase):
         'transfers':  [self.transfer1],
 
         # These parameters are set to their default values.
-        'change_address': None,
+        'changeAddress':  None,
         'inputs':         None,
       },
     )
@@ -300,11 +300,11 @@ class PrepareTransferRequestFilterTestCase(BaseFilterTestCase):
 
   def test_fail_change_address_wrong_type(self):
     """
-    ``change_address`` is not a TrytesCompatible value.
+    ``changeAddress`` is not a TrytesCompatible value.
     """
     self.assertFilterErrors(
       {
-        'change_address': text_type(self.trytes3, 'ascii'),
+        'changeAddress':  text_type(self.trytes3, 'ascii'),
 
         'seed': Seed(self.trytes1),
 
@@ -314,17 +314,17 @@ class PrepareTransferRequestFilterTestCase(BaseFilterTestCase):
       },
 
       {
-        'change_address': [f.Type.CODE_WRONG_TYPE],
+        'changeAddress':  [f.Type.CODE_WRONG_TYPE],
       },
     )
 
   def test_fail_change_address_not_trytes(self):
     """
-    ``change_address`` contains invalid characters.
+    ``changeAddress`` contains invalid characters.
     """
     self.assertFilterErrors(
       {
-        'change_address': b'not valid; must contain only uppercase and "9"',
+        'changeAddress':  b'not valid; must contain only uppercase and "9"',
 
         'seed': Seed(self.trytes1),
 
@@ -334,7 +334,7 @@ class PrepareTransferRequestFilterTestCase(BaseFilterTestCase):
       },
 
       {
-        'change_address': [Trytes.CODE_NOT_TRYTES],
+        'changeAddress':  [Trytes.CODE_NOT_TRYTES],
       },
     )
 
@@ -1119,7 +1119,7 @@ class PrepareTransferCommandTestCase(TestCase):
           ),
         ],
 
-        change_address =
+        changeAddress =
           Address(
             b'TESTVALUEFOUR9DONTUSEINPRODUCTION99999WJ'
             b'RBOSBIMNTGDYKUDYYFJFGZOHORYSQPCWJRKHIOVIY',
@@ -1951,7 +1951,7 @@ class PrepareTransferCommandTestCase(TestCase):
             ),
           ],
 
-          change_address =
+          changeAddress =
             Address(
               b'TESTVALUEFOUR9DONTUSEINPRODUCTION99999WJ'
               b'RBOSBIMNTGDYKUDYYFJFGZOHORYSQPCWJRKHIOVIY',

--- a/test/commands/extended/replay_bundle_test.py
+++ b/test/commands/extended/replay_bundle_test.py
@@ -34,9 +34,9 @@ class ReplayBundleRequestFilterTestCase(BaseFilterTestCase):
     Request is valid.
     """
     request = {
-      'depth':                100,
-      'min_weight_magnitude': 18,
-      'transaction':          TransactionHash(self.trytes1),
+      'depth':              100,
+      'minWeightMagnitude': 18,
+      'transaction':        TransactionHash(self.trytes1),
     }
 
     filter_ = self._filter(request)
@@ -54,8 +54,8 @@ class ReplayBundleRequestFilterTestCase(BaseFilterTestCase):
       'transaction': binary_type(self.trytes1),
 
       # These values must still be ints, however.
-      'depth':                100,
-      'min_weight_magnitude': 18,
+      'depth':              100,
+      'minWeightMagnitude': 18,
     })
 
     self.assertFilterPasses(filter_)
@@ -63,9 +63,9 @@ class ReplayBundleRequestFilterTestCase(BaseFilterTestCase):
       filter_.cleaned_data,
 
       {
-        'depth':                100,
-        'min_weight_magnitude': 18,
-        'transaction':          TransactionHash(self.trytes1),
+        'depth':              100,
+        'minWeightMagnitude': 18,
+        'transaction':        TransactionHash(self.trytes1),
       },
     )
 
@@ -77,9 +77,9 @@ class ReplayBundleRequestFilterTestCase(BaseFilterTestCase):
       {},
 
       {
-        'depth':                [f.FilterMapper.CODE_MISSING_KEY],
-        'min_weight_magnitude': [f.FilterMapper.CODE_MISSING_KEY],
-        'transaction':          [f.FilterMapper.CODE_MISSING_KEY],
+        'depth':              [f.FilterMapper.CODE_MISSING_KEY],
+        'minWeightMagnitude': [f.FilterMapper.CODE_MISSING_KEY],
+        'transaction':        [f.FilterMapper.CODE_MISSING_KEY],
       },
     )
 
@@ -89,9 +89,9 @@ class ReplayBundleRequestFilterTestCase(BaseFilterTestCase):
     """
     self.assertFilterErrors(
       {
-        'depth':                100,
-        'min_weight_magnitude': 18,
-        'transaction':          TransactionHash(self.trytes1),
+        'depth':              100,
+        'minWeightMagnitude': 18,
+        'transaction':        TransactionHash(self.trytes1),
 
         # That's a real nasty habit you got there.
         'foo': 'bar',
@@ -110,8 +110,8 @@ class ReplayBundleRequestFilterTestCase(BaseFilterTestCase):
       {
         'transaction': None,
 
-        'depth':                100,
-        'min_weight_magnitude': 18,
+        'depth':              100,
+        'minWeightMagnitude': 18,
       },
 
       {
@@ -127,8 +127,8 @@ class ReplayBundleRequestFilterTestCase(BaseFilterTestCase):
       {
         'transaction': text_type(self.trytes1, 'ascii'),
 
-        'depth':                100,
-        'min_weight_magnitude': 18,
+        'depth':              100,
+        'minWeightMagnitude': 18,
       },
 
       {
@@ -144,8 +144,8 @@ class ReplayBundleRequestFilterTestCase(BaseFilterTestCase):
       {
         'transaction': b'not valid; must contain only uppercase and "9"',
 
-        'depth':                100,
-        'min_weight_magnitude': 18,
+        'depth':              100,
+        'minWeightMagnitude': 18,
       },
 
       {
@@ -161,8 +161,8 @@ class ReplayBundleRequestFilterTestCase(BaseFilterTestCase):
       {
         'depth': None,
 
-        'min_weight_magnitude': 18,
-        'transaction':          TransactionHash(self.trytes1),
+        'minWeightMagnitude': 18,
+        'transaction':        TransactionHash(self.trytes1),
       },
 
       {
@@ -179,8 +179,8 @@ class ReplayBundleRequestFilterTestCase(BaseFilterTestCase):
         # Too ambiguous; it's gotta be an int.
         'depth': '4',
 
-        'min_weight_magnitude': 18,
-        'transaction':          TransactionHash(self.trytes1),
+        'minWeightMagnitude': 18,
+        'transaction':        TransactionHash(self.trytes1),
       },
 
       {
@@ -197,8 +197,8 @@ class ReplayBundleRequestFilterTestCase(BaseFilterTestCase):
         # Even with an empty fpart, float value is not valid.
         'depth': 8.0,
 
-        'min_weight_magnitude': 18,
-        'transaction':          TransactionHash(self.trytes1),
+        'minWeightMagnitude': 18,
+        'transaction':        TransactionHash(self.trytes1),
       },
 
       {
@@ -214,8 +214,8 @@ class ReplayBundleRequestFilterTestCase(BaseFilterTestCase):
       {
         'depth': 0,
 
-        'min_weight_magnitude': 18,
-        'transaction':          TransactionHash(self.trytes1),
+        'minWeightMagnitude': 18,
+        'transaction':        TransactionHash(self.trytes1),
       },
 
       {
@@ -225,71 +225,71 @@ class ReplayBundleRequestFilterTestCase(BaseFilterTestCase):
 
   def test_fail_min_weight_magnitude_null(self):
     """
-    ``min_weight_magnitude`` is null.
+    ``minWeightMagnitude`` is null.
     """
     self.assertFilterErrors(
       {
-        'min_weight_magnitude': None,
+        'minWeightMagnitude': None,
 
         'depth':        100,
         'transaction':  TransactionHash(self.trytes1),
       },
 
       {
-        'min_weight_magnitude': [f.Required.CODE_EMPTY],
+        'minWeightMagnitude': [f.Required.CODE_EMPTY],
       },
     )
 
   def test_fail_min_weight_magnitude_string(self):
     """
-    ``min_weight_magnitude`` is a string.
+    ``minWeightMagnitude`` is a string.
     """
     self.assertFilterErrors(
       {
         # It's gotta be an int!
-        'min_weight_magnitude': '18',
+        'minWeightMagnitude': '18',
 
         'depth':        100,
         'transaction':  TransactionHash(self.trytes1),
       },
 
       {
-        'min_weight_magnitude': [f.Type.CODE_WRONG_TYPE],
+        'minWeightMagnitude': [f.Type.CODE_WRONG_TYPE],
       },
     )
 
   def test_fail_min_weight_magnitude_float(self):
     """
-    ``min_weight_magnitude`` is a float.
+    ``minWeightMagnitude`` is a float.
     """
     self.assertFilterErrors(
       {
         # Even with an empty fpart, float values are not valid.
-        'min_weight_magnitude': 18.0,
+        'minWeightMagnitude': 18.0,
 
         'depth':        100,
         'transaction':  TransactionHash(self.trytes1),
       },
 
       {
-        'min_weight_magnitude': [f.Type.CODE_WRONG_TYPE],
+        'minWeightMagnitude': [f.Type.CODE_WRONG_TYPE],
       },
     )
 
   def test_fail_min_weight_magnitude_too_small(self):
     """
-    ``min_weight_magnitude`` is < 1.
+    ``minWeightMagnitude`` is < 1.
     """
     self.assertFilterErrors(
       {
-        'min_weight_magnitude': 0,
+        'minWeightMagnitude': 0,
 
         'depth':        100,
         'transaction':  TransactionHash(self.trytes1),
       },
 
       {
-        'min_weight_magnitude': [f.Min.CODE_TOO_SMALL],
+        'minWeightMagnitude': [f.Min.CODE_TOO_SMALL],
       },
     )
 
@@ -598,9 +598,9 @@ class ReplayBundleCommandTestCase(TestCase):
           mock_send_trytes,
       ):
         response = self.command(
-          depth                 = 100,
-          min_weight_magnitude  = 18,
-          transaction           = bundle[0].hash,
+          depth               = 100,
+          minWeightMagnitude  = 18,
+          transaction         = bundle[0].hash,
         )
 
     self.assertDictEqual(response, send_trytes_response)

--- a/test/commands/extended/send_transfer_test.py
+++ b/test/commands/extended/send_transfer_test.py
@@ -73,10 +73,10 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
     Request is valid.
     """
     request = {
-      'change_address':       Address(self.trytes1),
-      'depth':                100,
-      'min_weight_magnitude': 18,
-      'seed':                 Seed(self.trytes2),
+      'changeAddress':      Address(self.trytes1),
+      'depth':              100,
+      'minWeightMagnitude': 18,
+      'seed':               Seed(self.trytes2),
 
       'inputs': [
         Address(self.trytes3),
@@ -101,7 +101,7 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
     """
     filter_ = self._filter({
       # Any TrytesCompatible values will work here.
-      'change_address': binary_type(self.trytes1),
+      'changeAddress':  binary_type(self.trytes1),
       'seed':           bytearray(self.trytes2),
 
       'inputs': [
@@ -115,8 +115,8 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
         self.transfer2
       ],
 
-      'depth':                100,
-      'min_weight_magnitude': 18,
+      'depth':              100,
+      'minWeightMagnitude': 18,
     })
 
     self.assertFilterPasses(filter_)
@@ -124,10 +124,10 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
       filter_.cleaned_data,
 
       {
-        'change_address':       Address(self.trytes1),
-        'depth':                100,
-        'min_weight_magnitude': 18,
-        'seed':                 Seed(self.trytes2),
+        'changeAddress':      Address(self.trytes1),
+        'depth':              100,
+        'minWeightMagnitude': 18,
+        'seed':               Seed(self.trytes2),
 
         'inputs': [
           Address(self.trytes3),
@@ -146,9 +146,9 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
     Request omits optional parameters.
     """
     filter_ = self._filter({
-      'depth':                100,
-      'min_weight_magnitude': 13,
-      'seed':                 Seed(self.trytes2),
+      'depth':              100,
+      'minWeightMagnitude': 13,
+      'seed':               Seed(self.trytes2),
 
       'transfers': [
         self.transfer1,
@@ -161,12 +161,12 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
       filter_.cleaned_data,
 
       {
-        'change_address':       None,
-        'inputs':               None,
+        'changeAddress':      None,
+        'inputs':             None,
 
-        'depth':                100,
-        'min_weight_magnitude': 13,
-        'seed':                 Seed(self.trytes2),
+        'depth':              100,
+        'minWeightMagnitude': 13,
+        'seed':               Seed(self.trytes2),
 
         'transfers': [
           self.transfer1,
@@ -183,10 +183,10 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
       {},
 
       {
-        'depth':                [f.FilterMapper.CODE_MISSING_KEY],
-        'min_weight_magnitude': [f.FilterMapper.CODE_MISSING_KEY],
-        'seed':                 [f.FilterMapper.CODE_MISSING_KEY],
-        'transfers':            [f.FilterMapper.CODE_MISSING_KEY],
+        'depth':              [f.FilterMapper.CODE_MISSING_KEY],
+        'minWeightMagnitude': [f.FilterMapper.CODE_MISSING_KEY],
+        'seed':               [f.FilterMapper.CODE_MISSING_KEY],
+        'transfers':          [f.FilterMapper.CODE_MISSING_KEY],
       },
     )
 
@@ -196,10 +196,10 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
     """
     self.assertFilterErrors(
       {
-        'depth':                100,
-        'min_weight_magnitude': 18,
-        'seed':                 Seed(self.trytes1),
-        'transfers':            [self.transfer1],
+        'depth':              100,
+        'minWeightMagnitude': 18,
+        'seed':               Seed(self.trytes1),
+        'transfers':          [self.transfer1],
 
         # Maybe he's not that smart; maybe he's like a worker bee who
         # only knows how to push buttons or something.
@@ -219,9 +219,9 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
       {
         'seed': None,
 
-        'depth':                100,
-        'min_weight_magnitude': 18,
-        'transfers':            [self.transfer1],
+        'depth':              100,
+        'minWeightMagnitude': 18,
+        'transfers':          [self.transfer1],
       },
 
       {
@@ -237,9 +237,9 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
       {
         'seed': text_type(self.trytes1, 'ascii'),
 
-        'depth':                100,
-        'min_weight_magnitude': 18,
-        'transfers':            [self.transfer1],
+        'depth':              100,
+        'minWeightMagnitude': 18,
+        'transfers':          [self.transfer1],
       },
 
       {
@@ -255,9 +255,9 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
       {
         'seed': b'not valid; must contain only uppercase and "9"',
 
-        'depth':                100,
-        'min_weight_magnitude': 18,
-        'transfers':            [self.transfer1],
+        'depth':              100,
+        'minWeightMagnitude': 18,
+        'transfers':          [self.transfer1],
       },
 
       {
@@ -273,9 +273,9 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
       {
         'transfers': self.transfer1,
 
-        'depth':                100,
-        'min_weight_magnitude': 18,
-        'seed':                 Seed(self.trytes1),
+        'depth':              100,
+        'minWeightMagnitude': 18,
+        'seed':               Seed(self.trytes1),
       },
 
       {
@@ -291,9 +291,9 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
       {
         'transfers': [],
 
-        'depth':                100,
-        'min_weight_magnitude': 18,
-        'seed':                 Seed(self.trytes1),
+        'depth':              100,
+        'minWeightMagnitude': 18,
+        'seed':               Seed(self.trytes1),
       },
 
       {
@@ -317,9 +317,9 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
           {'address': Address(self.trytes2), 'value': 42},
         ],
 
-        'depth':                100,
-        'min_weight_magnitude': 18,
-        'seed':                 Seed(self.trytes1),
+        'depth':              100,
+        'minWeightMagnitude': 18,
+        'seed':               Seed(self.trytes1),
       },
 
       {
@@ -330,39 +330,39 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
 
   def test_fail_change_address_wrong_type(self):
     """
-    ``change_address`` is not a TrytesCompatible value.
+    ``changeAddress`` is not a TrytesCompatible value.
     """
     self.assertFilterErrors(
       {
-        'change_address': text_type(self.trytes3, 'ascii'),
+        'changeAddress': text_type(self.trytes3, 'ascii'),
 
-        'depth':                100,
-        'min_weight_magnitude': 18,
-        'seed':                 Seed(self.trytes1),
-        'transfers':            [self.transfer1],
+        'depth':              100,
+        'minWeightMagnitude': 18,
+        'seed':               Seed(self.trytes1),
+        'transfers':          [self.transfer1],
       },
 
       {
-        'change_address': [f.Type.CODE_WRONG_TYPE],
+        'changeAddress': [f.Type.CODE_WRONG_TYPE],
       },
     )
 
   def test_fail_change_address_not_trytes(self):
     """
-    ``change_address`` contains invalid characters.
+    ``changeAddress`` contains invalid characters.
     """
     self.assertFilterErrors(
       {
-        'change_address': b'not valid; must contain only uppercase and "9"',
+        'changeAddress': b'not valid; must contain only uppercase and "9"',
 
-        'depth':                100,
-        'min_weight_magnitude': 18,
-        'seed':                 Seed(self.trytes1),
-        'transfers':            [self.transfer1],
+        'depth':              100,
+        'minWeightMagnitude': 18,
+        'seed':               Seed(self.trytes1),
+        'transfers':          [self.transfer1],
       },
 
       {
-        'change_address': [Trytes.CODE_NOT_TRYTES],
+        'changeAddress': [Trytes.CODE_NOT_TRYTES],
       },
     )
 
@@ -375,10 +375,10 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
         # Must be an array, even if there's only one input.
         'inputs': Address(self.trytes4),
 
-        'depth':                100,
-        'min_weight_magnitude': 18,
-        'seed':                 Seed(self.trytes1),
-        'transfers':            [self.transfer1],
+        'depth':              100,
+        'minWeightMagnitude': 18,
+        'seed':               Seed(self.trytes1),
+        'transfers':          [self.transfer1],
       },
 
       {
@@ -407,10 +407,10 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
           b'9' * 82,
         ],
 
-        'depth':                100,
-        'min_weight_magnitude': 18,
-        'seed':                 Seed(self.trytes1),
-        'transfers':            [self.transfer1],
+        'depth':              100,
+        'minWeightMagnitude': 18,
+        'seed':               Seed(self.trytes1),
+        'transfers':          [self.transfer1],
       },
 
       {
@@ -432,9 +432,9 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
       {
         'depth': None,
 
-        'min_weight_magnitude': 18,
-        'seed':                 Seed(self.trytes1),
-        'transfers':            [self.transfer1],
+        'minWeightMagnitude': 18,
+        'seed':               Seed(self.trytes1),
+        'transfers':          [self.transfer1],
       },
 
       {
@@ -451,9 +451,9 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
         # Too ambiguous; it must be an int.
         'depth': '2',
 
-        'min_weight_magnitude': 18,
-        'seed':                 Seed(self.trytes1),
-        'transfers':            [self.transfer1],
+        'minWeightMagnitude': 18,
+        'seed':               Seed(self.trytes1),
+        'transfers':          [self.transfer1],
       },
 
       {
@@ -470,9 +470,9 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
         # Even with an empty fpart, floats are invalid.
         'depth': 100.0,
 
-        'min_weight_magnitude': 18,
-        'seed':                 Seed(self.trytes1),
-        'transfers':            [self.transfer1],
+        'minWeightMagnitude': 18,
+        'seed':               Seed(self.trytes1),
+        'transfers':          [self.transfer1],
       },
 
       {
@@ -488,9 +488,9 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
       {
         'depth': 0,
 
-        'min_weight_magnitude': 18,
-        'seed':                 Seed(self.trytes1),
-        'transfers':            [self.transfer1],
+        'minWeightMagnitude': 18,
+        'seed':               Seed(self.trytes1),
+        'transfers':          [self.transfer1],
       },
 
       {
@@ -500,11 +500,11 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
 
   def test_fail_min_weight_magnitude_null(self):
     """
-    ``min_weight_magnitude`` is null.
+    ``minWeightMagnitude`` is null.
     """
     self.assertFilterErrors(
       {
-        'min_weight_magnitude': None,
+        'minWeightMagnitude': None,
 
         'depth':      100,
         'seed':       Seed(self.trytes1),
@@ -512,18 +512,18 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
       },
 
       {
-        'min_weight_magnitude': [f.Required.CODE_EMPTY],
+        'minWeightMagnitude': [f.Required.CODE_EMPTY],
       },
     )
 
   def test_fail_min_weight_magnitude_string(self):
     """
-    ``min_weight_magnitude`` is a string.
+    ``minWeightMagnitude`` is a string.
     """
     self.assertFilterErrors(
       {
         # Nope; it's gotta be an int.
-        'min_weight_magnitude': '18',
+        'minWeightMagnitude': '18',
 
         'depth':      100,
         'seed':       Seed(self.trytes1),
@@ -531,18 +531,18 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
       },
 
       {
-        'min_weight_magnitude': [f.Type.CODE_WRONG_TYPE],
+        'minWeightMagnitude': [f.Type.CODE_WRONG_TYPE],
       },
     )
 
   def test_fail_min_weight_magnitude_float(self):
     """
-    ``min_weight_magnitude`` is a float.
+    ``minWeightMagnitude`` is a float.
     """
     self.assertFilterErrors(
       {
         # Even with an empty fpart, floats are invalid.
-        'min_weight_magnitude': 18.0,
+        'minWeightMagnitude': 18.0,
 
         'depth':      100,
         'seed':       Seed(self.trytes1),
@@ -550,17 +550,17 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
       },
 
       {
-        'min_weight_magnitude': [f.Type.CODE_WRONG_TYPE],
+        'minWeightMagnitude': [f.Type.CODE_WRONG_TYPE],
       },
     )
 
   def test_fail_min_weight_magnitude_too_small(self):
     """
-    ``min_weight_magnitude`` is < 1.
+    ``minWeightMagnitude`` is < 1.
     """
     self.assertFilterErrors(
       {
-        'min_weight_magnitude': 0,
+        'minWeightMagnitude': 0,
 
         'depth':      100,
         'seed':       Seed(self.trytes1),
@@ -568,7 +568,7 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
       },
 
       {
-        'min_weight_magnitude': [f.Min.CODE_TOO_SMALL],
+        'minWeightMagnitude': [f.Min.CODE_TOO_SMALL],
       },
     )
 
@@ -656,9 +656,9 @@ class SendTransferCommandTestCase(TestCase):
           mock_send_trytes,
       ):
         response = self.command(
-          depth                 = 100,
-          min_weight_magnitude  = 18,
-          seed                  = Seed.random(),
+          depth               = 100,
+          minWeightMagnitude  = 18,
+          seed                = Seed.random(),
 
           transfers = [
             ProposedTransaction(

--- a/test/commands/extended/send_trytes_test.py
+++ b/test/commands/extended/send_trytes_test.py
@@ -391,23 +391,18 @@ class SendTrytesCommandTestCase(TestCase):
       ],
     })
 
-    self.adapter.seed_response('broadcastTransactions', {
-      'trytes': [
-        text_type(self.trytes1, 'ascii'),
-        text_type(self.trytes2, 'ascii'),
-      ],
-    })
-
+    self.adapter.seed_response('broadcastTransactions', {})
     self.adapter.seed_response('storeTransactions', {})
 
-    response = self.command(
-      trytes = [
-        TransactionTrytes(self.trytes1),
-        TransactionTrytes(self.trytes2),
-      ],
+    trytes = [
+      TransactionTrytes(self.trytes1),
+      TransactionTrytes(self.trytes2),
+    ]
 
-      depth = 100,
-      minWeightMagnitude = 18,
+    response = self.command(
+      trytes              = trytes,
+      depth               = 100,
+      minWeightMagnitude  = 18,
     )
 
-    self.assertDictEqual(response, {})
+    self.assertDictEqual(response, {'trytes': trytes})

--- a/test/commands/extended/send_trytes_test.py
+++ b/test/commands/extended/send_trytes_test.py
@@ -6,12 +6,12 @@ from unittest import TestCase
 
 import filters as f
 from filters.test import BaseFilterTestCase
-from iota import BadApiResponse, Iota, TransactionHash, TransactionTrytes, \
-  TryteString
+from six import text_type, binary_type
+
+from iota import Iota, TransactionTrytes, TryteString
 from iota.adapter import MockAdapter
 from iota.commands.extended.send_trytes import SendTrytesCommand
 from iota.filters import Trytes
-from six import text_type, binary_type
 
 
 class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
@@ -33,8 +33,8 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
     Request is valid.
     """
     request = {
-      'depth':                100,
-      'min_weight_magnitude': 18,
+      'depth':              100,
+      'minWeightMagnitude': 18,
 
       'trytes': [
         TransactionTrytes(self.trytes1),
@@ -60,8 +60,8 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
       ],
 
       # These still have to be ints, however.
-      'depth':                100,
-      'min_weight_magnitude': 18,
+      'depth':              100,
+      'minWeightMagnitude': 18,
     })
 
     self.assertFilterPasses(filter_)
@@ -69,8 +69,8 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
       filter_.cleaned_data,
 
       {
-        'depth':                100,
-        'min_weight_magnitude': 18,
+        'depth':              100,
+        'minWeightMagnitude': 18,
 
         'trytes': [
           TransactionTrytes(self.trytes1),
@@ -87,9 +87,9 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
       {},
 
       {
-        'depth':                [f.FilterMapper.CODE_MISSING_KEY],
-        'min_weight_magnitude': [f.FilterMapper.CODE_MISSING_KEY],
-        'trytes':               [f.FilterMapper.CODE_MISSING_KEY],
+        'depth':              [f.FilterMapper.CODE_MISSING_KEY],
+        'minWeightMagnitude': [f.FilterMapper.CODE_MISSING_KEY],
+        'trytes':             [f.FilterMapper.CODE_MISSING_KEY],
       },
     )
 
@@ -99,9 +99,9 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
     """
     self.assertFilterErrors(
       {
-        'depth':                100,
-        'min_weight_magnitude': 18,
-        'trytes':               [TryteString(self.trytes1)],
+        'depth':              100,
+        'minWeightMagnitude': 18,
+        'trytes':             [TryteString(self.trytes1)],
 
         # Oh, bother.
         'foo': 'bar',
@@ -120,8 +120,8 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
       {
         'depth': None,
 
-        'min_weight_magnitude': 18,
-        'trytes':               [TryteString(self.trytes1)],
+        'minWeightMagnitude': 18,
+        'trytes':             [TryteString(self.trytes1)],
       },
 
       {
@@ -138,8 +138,8 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
         # Too ambiguous; it's gotta be an int.
         'depth': '4',
 
-        'min_weight_magnitude': 18,
-        'trytes':               [TryteString(self.trytes1)],
+        'minWeightMagnitude': 18,
+        'trytes':             [TryteString(self.trytes1)],
       },
 
       {
@@ -156,8 +156,8 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
         # Even with an empty fpart, float value is not valid.
         'depth': 8.0,
 
-        'min_weight_magnitude': 18,
-        'trytes':               [TryteString(self.trytes1)],
+        'minWeightMagnitude': 18,
+        'trytes':             [TryteString(self.trytes1)],
       },
 
       {
@@ -173,8 +173,8 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
       {
         'depth': 0,
 
-        'min_weight_magnitude': 18,
-        'trytes':               [TryteString(self.trytes1)],
+        'minWeightMagnitude': 18,
+        'trytes':             [TryteString(self.trytes1)],
       },
 
       {
@@ -184,71 +184,71 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
 
   def test_fail_min_weight_magnitude_null(self):
     """
-    ``min_weight_magnitude`` is null.
+    ``minWeightMagnitude`` is null.
     """
     self.assertFilterErrors(
       {
-        'min_weight_magnitude': None,
+        'minWeightMagnitude': None,
 
         'depth':  100,
         'trytes': [TryteString(self.trytes1)],
       },
 
       {
-        'min_weight_magnitude': [f.Required.CODE_EMPTY],
+        'minWeightMagnitude': [f.Required.CODE_EMPTY],
       },
     )
 
   def test_fail_min_weight_magnitude_string(self):
     """
-    ``min_weight_magnitude`` is a string.
+    ``minWeightMagnitude`` is a string.
     """
     self.assertFilterErrors(
       {
         # It's gotta be an int!
-        'min_weight_magnitude': '18',
+        'minWeightMagnitude': '18',
 
         'depth':  100,
         'trytes': [TryteString(self.trytes1)],
       },
 
       {
-        'min_weight_magnitude': [f.Type.CODE_WRONG_TYPE],
+        'minWeightMagnitude': [f.Type.CODE_WRONG_TYPE],
       },
     )
 
   def test_fail_min_weight_magnitude_float(self):
     """
-    ``min_weight_magnitude`` is a float.
+    ``minWeightMagnitude`` is a float.
     """
     self.assertFilterErrors(
       {
         # Even with an empty fpart, float values are not valid.
-        'min_weight_magnitude': 18.0,
+        'minWeightMagnitude': 18.0,
 
         'depth':  100,
         'trytes': [TryteString(self.trytes1)],
       },
 
       {
-        'min_weight_magnitude': [f.Type.CODE_WRONG_TYPE],
+        'minWeightMagnitude': [f.Type.CODE_WRONG_TYPE],
       },
     )
 
   def test_fail_min_weight_magnitude_too_small(self):
     """
-    ``min_weight_magnitude`` is < 1.
+    ``minWeightMagnitude`` is < 1.
     """
     self.assertFilterErrors(
       {
-        'min_weight_magnitude': 0,
+        'minWeightMagnitude': 0,
 
         'depth':  100,
         'trytes': [TryteString(self.trytes1)],
       },
 
       {
-        'min_weight_magnitude': [f.Min.CODE_TOO_SMALL],
+        'minWeightMagnitude': [f.Min.CODE_TOO_SMALL],
       },
     )
 
@@ -260,8 +260,8 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
       {
         'trytes': None,
 
-        'depth':                100,
-        'min_weight_magnitude': 18,
+        'depth':              100,
+        'minWeightMagnitude': 18,
       },
 
       {
@@ -279,8 +279,8 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
         # send.
         'trytes': TryteString(self.trytes1),
 
-        'depth':                100,
-        'min_weight_magnitude': 18,
+        'depth':              100,
+        'minWeightMagnitude': 18,
       },
 
       {
@@ -296,8 +296,8 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
       {
         'trytes': [],
 
-        'depth':                100,
-        'min_weight_magnitude': 18,
+        'depth':              100,
+        'minWeightMagnitude': 18,
       },
 
       {
@@ -327,8 +327,8 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
           b'9' * (TransactionTrytes.LEN + 1),
         ],
 
-        'depth':                100,
-        'min_weight_magnitude': 18,
+        'depth':              100,
+        'minWeightMagnitude': 18,
       },
 
       {
@@ -407,277 +407,7 @@ class SendTrytesCommandTestCase(TestCase):
       ],
 
       depth = 100,
-      min_weight_magnitude = 18,
+      minWeightMagnitude = 18,
     )
 
     self.assertDictEqual(response, {})
-
-    self.assertListEqual(
-      self.adapter.requests,
-
-      [
-        {
-          'command':  'getTransactionsToApprove',
-          'depth':    100,
-        },
-
-        {
-          'command': 'attachToTangle',
-
-          'trunk_transaction':    TransactionHash(self.transaction1),
-          'branch_transaction':   TransactionHash(self.transaction2),
-          'min_weight_magnitude': 18,
-
-          'trytes': [
-            TransactionTrytes(self.trytes1),
-            TransactionTrytes(self.trytes2),
-          ],
-        },
-
-        {
-          'command': 'broadcastTransactions',
-
-          'trytes': [
-            TransactionTrytes(self.trytes1),
-            TransactionTrytes(self.trytes2),
-          ],
-        },
-
-        {
-          'command': 'storeTransactions',
-
-          'trytes': [
-            TransactionTrytes(self.trytes1),
-            TransactionTrytes(self.trytes2),
-          ],
-        },
-      ],
-    )
-
-  def test_get_transactions_to_approve_fails(self):
-    """
-    The ``getTransactionsToApprove`` call fails.
-    """
-    self.adapter.seed_response('getTransactionsToApprove', {
-      'error': "I'm a teapot.",
-    })
-
-    with self.assertRaises(BadApiResponse):
-      self.command(
-        trytes = [
-          TryteString(self.trytes1),
-          TryteString(self.trytes2),
-        ],
-
-        depth = 100,
-        min_weight_magnitude = 18,
-      )
-
-    # As soon as a request fails, the process halts.
-    # Note that this operation is not atomic!
-    self.assertListEqual(
-      self.adapter.requests,
-
-      [
-        {
-          'command':  'getTransactionsToApprove',
-          'depth':    100,
-        },
-      ],
-    )
-
-  def test_attach_to_tangle_fails(self):
-    """
-    The ``attachToTangle`` call fails.
-    """
-    self.adapter.seed_response('getTransactionsToApprove', {
-      'trunkTransaction':   text_type(self.transaction1, 'ascii'),
-      'branchTransaction':  text_type(self.transaction2, 'ascii'),
-    })
-
-    self.adapter.seed_response('attachToTangle', {
-      'error': "I'm a teapot.",
-    })
-
-    with self.assertRaises(BadApiResponse):
-      self.command(
-        trytes = [
-          TransactionTrytes(self.trytes1),
-          TransactionTrytes(self.trytes2),
-        ],
-
-        depth = 100,
-        min_weight_magnitude = 18,
-      )
-
-    # As soon as a request fails, the process halts.
-    # Note that this operation is not atomic!
-    self.assertListEqual(
-      self.adapter.requests,
-
-      [
-        {
-          'command':  'getTransactionsToApprove',
-          'depth':    100,
-        },
-
-        {
-          'command': 'attachToTangle',
-
-          'trunk_transaction':    TransactionHash(self.transaction1),
-          'branch_transaction':   TransactionHash(self.transaction2),
-          'min_weight_magnitude': 18,
-
-          'trytes': [
-            TransactionTrytes(self.trytes1),
-            TransactionTrytes(self.trytes2),
-          ],
-        },
-      ],
-    )
-
-  def test_broadcast_transactions_fails(self):
-    """
-    The ``broadcastTransactions`` call fails.
-    """
-    self.adapter.seed_response('getTransactionsToApprove', {
-      'trunkTransaction':   text_type(self.transaction1, 'ascii'),
-      'branchTransaction':  text_type(self.transaction2, 'ascii'),
-    })
-
-    self.adapter.seed_response('attachToTangle', {
-      'trytes': [
-        text_type(self.trytes1, 'ascii'),
-        text_type(self.trytes2, 'ascii'),
-      ],
-    })
-
-    self.adapter.seed_response('broadcastTransactions', {
-      'error': "I'm a teapot.",
-    })
-
-    with self.assertRaises(BadApiResponse):
-      self.command(
-        trytes = [
-          TransactionTrytes(self.trytes1),
-          TransactionTrytes(self.trytes2),
-        ],
-
-        depth = 100,
-        min_weight_magnitude = 18,
-      )
-
-    # As soon as a request fails, the process halts.
-    # Note that this operation is not atomic!
-    self.assertListEqual(
-      self.adapter.requests,
-
-      [
-        {
-          'command':  'getTransactionsToApprove',
-          'depth':    100,
-        },
-
-        {
-          'command': 'attachToTangle',
-
-          'trunk_transaction':    TransactionHash(self.transaction1),
-          'branch_transaction':   TransactionHash(self.transaction2),
-          'min_weight_magnitude': 18,
-
-          'trytes': [
-            TransactionTrytes(self.trytes1),
-            TransactionTrytes(self.trytes2),
-          ],
-        },
-
-        {
-          'command': 'broadcastTransactions',
-
-          'trytes': [
-            TransactionTrytes(self.trytes1),
-            TransactionTrytes(self.trytes2),
-          ],
-        },
-      ],
-    )
-
-  def test_store_transactions_fails(self):
-    """
-    The ``storeTransactions`` call fails.
-    """
-    self.adapter.seed_response('getTransactionsToApprove', {
-      'trunkTransaction':   text_type(self.transaction1, 'ascii'),
-      'branchTransaction':  text_type(self.transaction2, 'ascii'),
-    })
-
-    self.adapter.seed_response('attachToTangle', {
-      'trytes': [
-        text_type(self.trytes1, 'ascii'),
-        text_type(self.trytes2, 'ascii'),
-      ],
-    })
-
-    self.adapter.seed_response('broadcastTransactions', {
-      'trytes': [
-        text_type(self.trytes1, 'ascii'),
-        text_type(self.trytes2, 'ascii'),
-      ],
-    })
-
-    self.adapter.seed_response('storeTransactions', {
-      'error': "I'm a teapot.",
-    })
-
-    with self.assertRaises(BadApiResponse):
-      self.command(
-        trytes = [
-          TransactionTrytes(self.trytes1),
-          TransactionTrytes(self.trytes2),
-        ],
-
-        depth = 100,
-        min_weight_magnitude = 18,
-      )
-
-    self.assertListEqual(
-      self.adapter.requests,
-
-      [
-        {
-          'command':  'getTransactionsToApprove',
-          'depth':    100,
-        },
-
-        {
-          'command': 'attachToTangle',
-
-          'trunk_transaction':    TransactionHash(self.transaction1),
-          'branch_transaction':   TransactionHash(self.transaction2),
-          'min_weight_magnitude': 18,
-
-          'trytes': [
-            TransactionTrytes(self.trytes1),
-            TransactionTrytes(self.trytes2),
-          ],
-        },
-
-        {
-          'command': 'broadcastTransactions',
-
-          'trytes': [
-            TransactionTrytes(self.trytes1),
-            TransactionTrytes(self.trytes2),
-          ],
-        },
-
-        {
-          'command': 'storeTransactions',
-
-          'trytes': [
-            TransactionTrytes(self.trytes1),
-            TransactionTrytes(self.trytes2),
-          ],
-        },
-      ],
-    )

--- a/test/types_test.py
+++ b/test/types_test.py
@@ -465,6 +465,26 @@ class TryteStringTestCase(TestCase):
 
     self.assertEqual(trytes.as_string(), '你好，世界！')
 
+  def test_as_string_strip(self):
+    """
+    Strip trailing padding from a TryteString before converting.
+    """
+    # Note odd number of trytes!
+    trytes = TryteString(b'LH9GYEMHCF9GWHZFEELHVFOEOHNEEEWHZFUD9999999999999')
+
+    self.assertEqual(trytes.as_string(), '你好，世界！')
+
+  def test_as_string_no_strip(self):
+    """
+    Prevent stripping trailing padding when converting to string.
+    """
+    trytes = TryteString(b'LH9GYEMHCF9GWHZFEELHVFOEOHNEEEWHZFUD999999999999')
+
+    self.assertEqual(
+      trytes.as_string(strip_padding=False),
+      '你好，世界！\x00\x00\x00\x00\x00\x00',
+    )
+
   def test_as_string_not_utf8_errors_strict(self):
     """
     The tryte sequence does not represent a valid UTF-8 sequence, and


### PR DESCRIPTION
- Fixed incorrect case of API method parameters (changed `snake_case` to `camelCase`).
- `SendTrytesCommand` now correctly broadcasts POW'd trytes.
- Fixed incorrect return values for `BroadcastAndStoreCommand`, `BroadcastTransactionsCommand` and `StoreTransactionsCommand`.
- `AttachToTangleCommand` now returns `TransactionTrytes`.
- [#15] Implemented `RoutingWrapper`.
- Added `--pow-uri` option to `examples/shell.py`.  If specified, POW requests will be routed to a different node.
- Added `--debug` option to `examples/shell.py`.  If specified, all HTTP requests/responses will be logged to stderr.
- `TryteString.as_string()` now strips trailing `9` trytes by default.