### PR TITLE
1.1.0

### DIFF
--- a/examples/sandbox.py
+++ b/examples/sandbox.py
@@ -1,0 +1,55 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, \
+  unicode_literals
+
+from iota import *
+from iota.adapter.sandbox import SandboxAdapter
+
+
+# Create the API object.
+iota =\
+  Iota(
+    # To use sandbox mode, inject a ``SandboxAdapter``.
+    adapter = SandboxAdapter(
+      # URI of the sandbox node.
+      uri = 'https://sandbox.iotatoken.com/api/v1/',
+
+      # Access token used to authenticate requests.
+      # Contact the node maintainer to get an access token.
+      auth_token = 'auth token goes here',
+    ),
+
+    # Seed used for cryptographic functions.
+    # If null, a random seed will be generated.
+    seed = b'SEED9GOES9HERE',
+  )
+
+# Example of sending a transfer using the sandbox.
+# For more information, see :py:meth:`Iota.send_transfer`.
+# noinspection SpellCheckingInspection
+iota.send_transfer(
+  depth = 100,
+
+  # One or more :py:class:`ProposedTransaction` objects to add to the
+  # bundle.
+  transfers = [
+    ProposedTransaction(
+      # Recipient of the transfer.
+      address =
+        Address(
+          b'TESTVALUE9DONTUSEINPRODUCTION99999FBFFTG'
+          b'QFWEHEL9KCAFXBJBXGE9HID9XCOHFIDABHDG9AHDR'
+        ),
+
+      # Amount of IOTA to transfer.
+      # This value may be zero.
+      value = 42,
+
+      # Optional tag to attach to the transfer.
+      tag = Tag(b'EXAMPLE'),
+
+      # Optional message to include with the transfer.
+      message = TryteString.from_string('Hello, Tangle!'),
+    ),
+  ],
+)

--- a/examples/shell.py
+++ b/examples/shell.py
@@ -34,15 +34,20 @@ def main(uri, testnet, pow_uri, debug_requests):
   if isinstance(seed, text_type):
     seed = seed.encode('ascii')
 
+  adapter_ = resolve_adapter(uri)
+
   # If ``pow_uri`` is specified, route POW requests to a separate node.
-  adapter_ = create_adapter(uri, debug_requests)
   if pow_uri:
-    pow_adapter = create_adapter(pow_uri, debug_requests)
+    pow_adapter = resolve_adapter(pow_uri)
 
     adapter_ =\
       RoutingWrapper(adapter_)\
         .add_route('attachToTangle', pow_adapter)\
         .add_route('interruptAttachingToTangle', pow_adapter)
+
+  # If ``debug_requests`` is specified, log HTTP requests/responses.
+  if debug_requests:
+    adapter_ = LogWrapper(adapter_, getLogger(__name__), INFO)
 
   iota = Iota(adapter_, seed=seed, testnet=testnet)
 
@@ -55,26 +60,6 @@ def main(uri, testnet, pow_uri, debug_requests):
   )
 
   start_shell(iota, _banner)
-
-
-def create_adapter(uri, debug):
-  # type: (Text, bool) -> BaseAdapter
-  """
-  Creates an adapter with the specified settings.
-
-  :param uri:
-    Node URI.
-
-  :param debug:
-    Whether to attach a LogWrapper to the adapter.
-  """
-  adapter_ = resolve_adapter(uri)
-
-  return (
-    LogWrapper(adapter_, getLogger(__name__), INFO)
-      if debug
-      else adapter_
-  )
 
 
 def start_shell(iota, _banner):
@@ -102,11 +87,11 @@ if __name__ == '__main__':
   parser.add_argument(
     '--uri',
       type    = text_type,
-      default = 'udp://localhost:14265/',
+      default = 'http://localhost:14265/',
 
       help =
         'URI of the node to connect to '
-        '(defaults to udp://localhost:14265/).',
+        '(defaults to http://localhost:14265/).',
   )
 
   parser.add_argument(

--- a/examples/shell.py
+++ b/examples/shell.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, \
 
 from argparse import ArgumentParser
 from getpass import getpass as secure_input
-from logging import INFO, basicConfig, getLogger
+from logging import DEBUG, basicConfig, getLogger
 from sys import argv, stderr
 
 from six import text_type
@@ -18,10 +18,10 @@ from iota import *
 
 from iota import __version__
 from iota.adapter import resolve_adapter
-from iota.adapter.wrappers import LogWrapper, RoutingWrapper
+from iota.adapter.wrappers import RoutingWrapper
 
 
-basicConfig(level=INFO, stream=stderr)
+basicConfig(level=DEBUG, stream=stderr)
 
 
 def main(uri, testnet, pow_uri, debug_requests):
@@ -47,7 +47,9 @@ def main(uri, testnet, pow_uri, debug_requests):
 
   # If ``debug_requests`` is specified, log HTTP requests/responses.
   if debug_requests:
-    adapter_ = LogWrapper(adapter_, getLogger(__name__), INFO)
+    logger = getLogger(__name__)
+    logger.setLevel(DEBUG)
+    adapter_.set_logger(logger)
 
   iota = Iota(adapter_, seed=seed, testnet=testnet)
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
   name        = 'PyOTA',
   description = 'IOTA API library for Python',
   url         = 'https://github.com/iotaledger/iota.lib.py',
-  version     = '1.1.0rc1',
+  version     = '1.1.0',
 
   packages              = find_packages('src'),
   include_package_data  = True,

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
   name        = 'PyOTA',
   description = 'IOTA API library for Python',
   url         = 'https://github.com/iotaledger/iota.lib.py',
-  version     = '1.0.0',
+  version     = '1.1.0b1',
 
   packages              = find_packages('src'),
   include_package_data  = True,

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
   name        = 'PyOTA',
   description = 'IOTA API library for Python',
   url         = 'https://github.com/iotaledger/iota.lib.py',
-  version     = '1.1.0b1',
+  version     = '1.1.0rc1',
 
   packages              = find_packages('src'),
   include_package_data  = True,

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
 
   install_requires = [
     'filters',
-    'requests',
+    'requests[security]',
     'six',
     'typing',
   ],

--- a/src/iota/adapter/sandbox.py
+++ b/src/iota/adapter/sandbox.py
@@ -1,0 +1,120 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, \
+  unicode_literals
+
+from typing import Optional, Text, Union
+
+from six import text_type
+
+from iota.adapter import HttpAdapter, SplitResult
+from iota.exceptions import with_context
+
+
+class SandboxAdapter(HttpAdapter):
+  """
+  HTTP adapter that sends requests to remote nodes operating in
+  "sandbox" mode.
+
+  In sandbox mode, the node will only accept authenticated requests
+  from clients, and certain jobs are completed asynchronously.
+
+  Note: for compatibility with Iota APIs, SandboxAdapter still operates
+  synchronously; it blocks until it determines that a job has completed
+  successfully.
+
+  References:
+    - https://github.com/iotaledger/iota.lib.py/issues/19
+    - https://github.com/iotaledger/documentation/blob/sandbox/source/index.html.md
+  """
+  DEFAULT_POLL_INTERVAL = 15
+  """
+  Number of seconds to wait between requests to check job status.
+  """
+
+  def __init__(self, uri, token, poll_interval=DEFAULT_POLL_INTERVAL):
+    # type: (Union[Text, SplitResult], Optional[Text], int) -> None
+    """
+    :param uri:
+      URI of the node to connect to.
+      ``https://` URIs are recommended!
+
+      Note: Make sure the URI specifies the correct path!
+
+      Example:
+
+      - Incorrect: ``https://sandbox.iota:14265``
+      - Correct:   ``https://sandbox.iota:14265/api/v1/``
+
+    :param token:
+      Authorization token used to authenticate requests.
+
+      Contact the node's maintainer to obtain a token.
+
+      If ``None``, the adapter will not include authorization metadata
+      with requests.
+
+    :param poll_interval:
+      Number of seconds to wait between requests to check job status.
+      Must be a positive integer.
+
+      Smaller values will cause the adapter to return a result sooner
+      (once the node completes the job), but it increases traffic to
+      the node (which may trip a rate limiter and/or incur additional
+      costs).
+    """
+    super(SandboxAdapter, self).__init__(uri)
+
+    if not (isinstance(token, text_type) or (token is None)):
+      raise with_context(
+        exc =
+          TypeError(
+            '``token`` must be a unicode string or ``None`` '
+            '(``exc.context`` has more info).'
+          ),
+
+        context = {
+          'token': token,
+        },
+      )
+
+    if token == '':
+      raise with_context(
+        exc =
+          ValueError(
+            'Set ``token=None`` if requests do not require authorization '
+            '(``exc.context`` has more info).',
+          ),
+
+        context = {
+          'token': token,
+        },
+      )
+
+    if not isinstance(poll_interval, int):
+      raise with_context(
+        exc =
+          TypeError(
+            '``poll_interval`` must be an int '
+            '(``exc.context`` has more info).',
+          ),
+
+        context = {
+          'poll_interval': poll_interval,
+        },
+      )
+
+    if poll_interval < 1:
+      raise with_context(
+        exc =
+          ValueError(
+            '``poll_interval`` must be >= 1 '
+            '(``exc.context`` has more info).',
+          ),
+
+        context = {
+          'poll_interval': poll_interval,
+        },
+      )
+
+    self.token          = token # type: Optional[Text]
+    self.poll_interval  = poll_interval # type: int

--- a/src/iota/adapter/sandbox.py
+++ b/src/iota/adapter/sandbox.py
@@ -12,6 +12,10 @@ from six import moves as compat, text_type
 from iota.adapter import HttpAdapter, SplitResult
 from iota.exceptions import with_context
 
+__all__ = [
+  'SandboxAdapter',
+]
+
 
 STATUS_ABORTED  = 'ABORTED'
 STATUS_FAILED   = 'FAILED'

--- a/src/iota/adapter/wrappers.py
+++ b/src/iota/adapter/wrappers.py
@@ -3,15 +3,12 @@ from __future__ import absolute_import, division, print_function, \
   unicode_literals
 
 from abc import ABCMeta, abstractmethod as abstract_method
-from logging import INFO, Logger
 from typing import Dict, Text
 
+from iota.adapter import AdapterSpec, BaseAdapter, resolve_adapter
 from six import with_metaclass
 
-from iota.adapter import AdapterSpec, BaseAdapter, resolve_adapter
-
 __all__ = [
-  'LogWrapper',
   'RoutingWrapper',
 ]
 
@@ -36,41 +33,6 @@ class BaseWrapper(with_metaclass(ABCMeta, BaseAdapter)):
     raise NotImplementedError(
       'Not implemented in {cls}.'.format(cls=type(self).__name__),
     )
-
-
-class LogWrapper(BaseWrapper):
-  """
-  Wrapper that sends all adapter requests and responses to a logger.
-
-  To use it, "wrap" the real adapter instance/spec::
-
-     logger = getLogger('...')
-     api    = Iota(LogWrapper('http://localhost:14265', logger))
-  """
-  def __init__(self, adapter, logger, level=INFO):
-    # type: (AdapterSpec, Logger, int) -> None
-    super(LogWrapper, self).__init__(adapter)
-
-    self.logger   = logger
-    self.level    = level
-
-  def send_request(self, payload, **kwargs):
-    # type: (dict, dict) -> dict
-    command = payload.get('command') or 'command'
-
-    self.logger.log(self.level, 'Sending {command}: {request!r}'.format(
-      command = command,
-      request = payload,
-    ))
-
-    response = self.adapter.send_request(payload, **kwargs)
-
-    self.logger.log(self.level, 'Receiving {command}: {response!r}'.format(
-      command   = command,
-      response  = response,
-    ))
-
-    return response
 
 
 class RoutingWrapper(BaseWrapper):

--- a/src/iota/api.py
+++ b/src/iota/api.py
@@ -533,7 +533,7 @@ class Iota(StrictIota):
     return self.getLatestInclusion(hashes=hashes)
 
   def get_new_addresses(self, index=0, count=1):
-    # type: (int, Optional[int]) -> List[Address]
+    # type: (int, Optional[int]) -> dict
     """
     Generates one or more new addresses from the seed.
 
@@ -550,10 +550,12 @@ class Iota(StrictIota):
       available unused address and return that.
 
     :return:
-      List of generated addresses.
+      Dict with the following items::
 
-      Note that this method always returns a list, even if only one
-      address is generated.
+         {
+           'addresses': List[Address],
+             Always a list, even if only one address was generated.
+         }
 
     References:
       - https://github.com/iotaledger/wiki/blob/master/api-proposal.md#getnewaddress

--- a/src/iota/commands/__init__.py
+++ b/src/iota/commands/__init__.py
@@ -22,7 +22,9 @@ __all__ = [
 ]
 
 command_registry = {} # type: Dict[Text, CommandMeta]
-"""Registry of commands, indexed by command name."""
+"""
+Registry of commands, indexed by command name.
+"""
 
 
 def discover_commands(package, recursively=True):
@@ -30,9 +32,11 @@ def discover_commands(package, recursively=True):
   """
   Automatically discover commands in the specified package.
 
-  :param package: Package path or reference.
-  :param recursively: If True, will descend recursively into
-    sub-packages.
+  :param package:
+    Package path or reference.
+
+  :param recursively:
+    If True, will descend recursively into sub-packages.
   """
   # :see: http://stackoverflow.com/a/25562415/
   if isinstance(package, string_types):
@@ -40,7 +44,7 @@ def discover_commands(package, recursively=True):
 
   for _, name, is_package in walk_packages(package.__path__):
     # Loading the module is good enough; the CommandMeta metaclass will
-    #   ensure that any commands in the module get registered.
+    # ensure that any commands in the module get registered.
     sub_package = import_module(package.__name__ + '.' + name)
 
     if recursively and is_package:
@@ -48,7 +52,9 @@ def discover_commands(package, recursively=True):
 
 
 class CommandMeta(ABCMeta):
-  """Automatically register new commands."""
+  """
+  Automatically register new commands.
+  """
   # noinspection PyShadowingBuiltins
   def __init__(cls, what, bases=None, dict=None):
     super(CommandMeta, cls).__init__(what, bases, dict)
@@ -60,7 +66,9 @@ class CommandMeta(ABCMeta):
 
 
 class BaseCommand(with_metaclass(CommandMeta)):
-  """An API command ready to send to the node."""
+  """
+  An API command ready to send to the node.
+  """
   command = None # Text
 
   def __init__(self, adapter):
@@ -77,7 +85,9 @@ class BaseCommand(with_metaclass(CommandMeta)):
 
   def __call__(self, **kwargs):
     # type: (dict) -> dict
-    """Sends the command to the node."""
+    """
+    Sends the command to the node.
+    """
     if self.called:
       raise with_context(
         exc = RuntimeError('Command has already been called.'),
@@ -131,12 +141,13 @@ class BaseCommand(with_metaclass(CommandMeta)):
     Modifies the request before sending it to the node.
 
     If this method returns a dict, it will replace the request
-      entirely.
+    entirely.
 
     Note:  the `command` parameter will be injected later; it is
-      not necessary for this method to include it.
+    not necessary for this method to include it.
 
-    :param request: Guaranteed to be a dict, but it might be empty.
+    :param request:
+      Guaranteed to be a dict, but it might be empty.
     """
     raise NotImplementedError(
       'Not implemented in {cls}.'.format(cls=type(self).__name__),
@@ -149,9 +160,10 @@ class BaseCommand(with_metaclass(CommandMeta)):
     Modifies the response from the node.
 
     If this method returns a dict, it will replace the response
-      entirely.
+    entirely.
 
-    :param response: Guaranteed to be a dict, but it might be empty.
+    :param response:
+      Guaranteed to be a dict, but it might be empty.
     """
     raise NotImplementedError(
       'Not implemented in {cls}.'.format(cls=type(self).__name__),
@@ -161,7 +173,7 @@ class BaseCommand(with_metaclass(CommandMeta)):
 class CustomCommand(BaseCommand):
   """
   Sends an arbitrary command to the node, with no request/response
-    validation.
+  validation.
 
   Useful for executing experimental/undocumented commands.
   """
@@ -179,9 +191,11 @@ class CustomCommand(BaseCommand):
 
 
 class RequestFilter(f.FilterChain):
-  """Template for filter applied to API requests."""
+  """
+  Template for filter applied to API requests.
+  """
   # Be more strict about missing/extra keys for requests, since they
-  #   tend to come from code that the developer has control over.
+  # tend to come from code that the developer has control over.
   def __init__(
       self,
       filter_map,
@@ -200,9 +214,11 @@ class RequestFilter(f.FilterChain):
 
 
 class ResponseFilter(f.FilterChain):
-  """Template for filter applied to API responses."""
+  """
+  Template for filter applied to API responses.
+  """
   # Be a little looser about missing/extra keys for responses, since we
-  #   can't control what the node sends us back.
+  # can't control what the node sends us back.
   def __init__(
       self,
       filter_map,
@@ -222,7 +238,9 @@ class ResponseFilter(f.FilterChain):
 
 
 class FilterCommand(with_metaclass(ABCMeta, BaseCommand)):
-  """Uses filters to manipulate request/response values."""
+  """
+  Uses filters to manipulate request/response values.
+  """
   @abstract_method
   def get_request_filter(self):
     # type: () -> Optional[RequestFilter]
@@ -230,8 +248,8 @@ class FilterCommand(with_metaclass(ABCMeta, BaseCommand)):
     Returns the filter that should be applied to the request (if any).
 
     Generally, this filter should be strict about validating/converting
-      the values in the request, to minimize the chance of an error
-      response from the node.
+    the values in the request, to minimize the chance of an error
+    response from the node.
     """
     raise NotImplementedError(
       'Not implemented in {cls}.'.format(cls=type(self).__name__),
@@ -244,8 +262,8 @@ class FilterCommand(with_metaclass(ABCMeta, BaseCommand)):
     Returns the filter that should be applied to the response (if any).
 
     Generally, this filter should be less concerned with validation and
-      more concerned with ensuring the response values have the correct
-      types, since we can't control what the node sends us.
+    more concerned with ensuring the response values have the correct
+    types, since we can't control what the node sends us.
     """
     raise NotImplementedError(
       'Not implemented in {cls}.'.format(cls=type(self).__name__),
@@ -270,8 +288,8 @@ class FilterCommand(with_metaclass(ABCMeta, BaseCommand)):
     # type: (dict, Optional[f.BaseFilter], Text) -> dict
     """
     Applies a filter to a value.  If the value does not pass the
-      filter, an exception will be raised with lots of contextual info
-      attached to it.
+    filter, an exception will be raised with lots of contextual info
+    attached to it.
     """
     if filter_:
       runner = f.FilterRunner(filter_, value)

--- a/src/iota/commands/extended/get_new_addresses.py
+++ b/src/iota/commands/extended/get_new_addresses.py
@@ -2,10 +2,11 @@
 from __future__ import absolute_import, division, print_function, \
   unicode_literals
 
-from typing import Optional
+from typing import List, Optional
 
 import filters as f
 
+from iota import Address
 from iota.commands import FilterCommand, RequestFilter
 from iota.commands.core.find_transactions import FindTransactionsCommand
 from iota.crypto.addresses import AddressGenerator
@@ -34,8 +35,17 @@ class GetNewAddressesCommand(FilterCommand):
   def _execute(self, request):
     count = request['count'] # type: Optional[int]
     index = request['index'] # type: int
-    seed = request['seed'] # type: Seed
+    seed  = request['seed'] # type: Seed
 
+    return {
+      'addresses': self._find_addresses(seed, index, count),
+    }
+
+  def _find_addresses(self, seed, index, count):
+    """
+    Find addresses matching the command parameters.
+    """
+    # type: (Seed, int, Optional[int]) -> List[Address]
     generator = AddressGenerator(seed)
 
     if count is None:

--- a/src/iota/commands/extended/prepare_transfer.py
+++ b/src/iota/commands/extended/prepare_transfer.py
@@ -98,7 +98,8 @@ class PrepareTransferCommand(FilterCommand):
 
       if bundle.balance < 0:
         if not change_address:
-          change_address = GetNewAddressesCommand(self.adapter)(seed=seed)[0]
+          change_address =\
+            GetNewAddressesCommand(self.adapter)(seed=seed)['addresses'][0]
 
         bundle.send_unspent_inputs_to(change_address)
 

--- a/src/iota/filters.py
+++ b/src/iota/filters.py
@@ -2,11 +2,11 @@
 from __future__ import absolute_import, division, print_function, \
   unicode_literals
 
+from six import moves as compat
 from typing import Text
 
 import filters as f
 from iota import Address, TryteString, TrytesCompatible
-from iota.adapter import resolve_adapter, InvalidUri
 from six import binary_type, text_type
 
 
@@ -49,10 +49,10 @@ class NodeUri(f.BaseFilter):
     if self._has_errors:
       return None
 
-    try:
-      resolve_adapter(value)
-    except InvalidUri:
-      return self._invalid_value(value, self.CODE_NOT_NODE_URI, exc_info=True)
+    parsed = compat.urllib_parse.urlparse(value)
+
+    if parsed.scheme != 'udp':
+      return self._invalid_value(value, self.CODE_NOT_NODE_URI)
 
     return value
 

--- a/test/adapter/sandbox_test.py
+++ b/test/adapter/sandbox_test.py
@@ -1,0 +1,77 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, \
+  unicode_literals
+
+from unittest import TestCase
+
+from iota.adapter.sandbox import SandboxAdapter
+
+
+class SandboxAdapterTestCase(TestCase):
+  def test_regular_command(self):
+    """
+    Sending a non-sandbox command to the node.
+    """
+    # :todo: Implement test.
+    self.skipTest('Not implemented yet.')
+
+  def test_sandbox_command(self):
+    """
+    Sending a sandbox command to the node.
+    """
+    # :todo: Implement test.
+    self.skipTest('Not implemented yet.')
+
+  def test_regular_command_null_token(self):
+    """
+    Sending commands to a sandbox that doesn't require authorization.
+
+    This is generally not recommended, but the sandbox node may use
+    other methods to control access (e.g., listen only on loopback
+    interface, use IP address whitelist, etc.).
+    """
+    # :todo: Implement test.
+    self.skipTest('Not implemented yet.')
+
+  def test_error_token_wrong_type(self):
+    """
+    ``token`` is not a string.
+    """
+    with self.assertRaises(TypeError):
+      # Nope; it has to be a unicode string.
+      SandboxAdapter('https://localhost', b'not valid')
+
+  def test_error_token_empty(self):
+    """
+    ``token`` is an empty string.
+    """
+    with self.assertRaises(ValueError):
+      # If the node does not require authorization, use ``None``.
+      SandboxAdapter('https://localhost', '')
+
+  def test_error_poll_interval_null(self):
+    """
+    ``poll_interval`` is ``None``.
+
+    The implications of allowing this are cool to think about...
+    but not implemented yet.
+    """
+    with self.assertRaises(TypeError):
+      # noinspection PyTypeChecker
+      SandboxAdapter('https://localhost', 'token', None)
+
+  def test_error_poll_interval_wrong_type(self):
+    """
+    ``poll_interval`` is not an int or float.
+    """
+    with self.assertRaises(TypeError):
+      # ``poll_interval`` must be an int.
+      # noinspection PyTypeChecker
+      SandboxAdapter('https://localhost', 'token', 42.0)
+
+  def test_error_poll_interval_too_small(self):
+    """
+    ``poll_interval`` is < 1.
+    """
+    with self.assertRaises(ValueError):
+      SandboxAdapter('https://localhost', 'token', 0)

--- a/test/adapter/sandbox_test.py
+++ b/test/adapter/sandbox_test.py
@@ -2,9 +2,13 @@
 from __future__ import absolute_import, division, print_function, \
   unicode_literals
 
+import json
 from unittest import TestCase
 
+from mock import Mock, patch
+
 from iota.adapter.sandbox import SandboxAdapter
+from test.adapter_test import create_http_response
 
 
 class SandboxAdapterTestCase(TestCase):
@@ -12,8 +16,31 @@ class SandboxAdapterTestCase(TestCase):
     """
     Sending a non-sandbox command to the node.
     """
-    # :todo: Implement test.
-    self.skipTest('Not implemented yet.')
+    adapter = SandboxAdapter('https://localhost', 'ACCESS-TOKEN')
+
+    expected_result = {
+      'message': 'Hello, IOTA!',
+    }
+
+    mocked_response = create_http_response(json.dumps(expected_result))
+    mocked_sender = Mock(return_value=mocked_response)
+
+    payload = {'command': 'helloWorld'}
+
+    # noinspection PyUnresolvedReferences
+    with patch.object(adapter, '_send_http_request', mocked_sender):
+      result = adapter.send_request(payload)
+
+    self.assertEqual(result, expected_result)
+
+    mocked_sender.assert_called_once_with(
+      payload = json.dumps(payload),
+
+      # Auth token automatically added to the HTTP request.
+      headers = {
+        'Authorization': 'token ACCESS-TOKEN',
+      },
+    )
 
   def test_sandbox_command(self):
     """

--- a/test/adapter/sandbox_test.py
+++ b/test/adapter/sandbox_test.py
@@ -42,7 +42,8 @@ class SandboxAdapterTestCase(TestCase):
 
       # Auth token automatically added to the HTTP request.
       headers = {
-        'Authorization': 'token ACCESS-TOKEN',
+        'Authorization':  'token ACCESS-TOKEN',
+        'Content-type':   'application/json',
       },
     )
 
@@ -229,10 +230,11 @@ class SandboxAdapterTestCase(TestCase):
       payload = json.dumps(payload),
       url     = adapter.node_url,
 
-      # No auth token, so no Authorization header.
-      # headers = {
-      #   'Authorization': 'token ACCESS-TOKEN',
-      # },
+      headers = {
+        # No auth token, so no Authorization header.
+        # 'Authorization':  'token ACCESS-TOKEN',
+        'Content-type':   'application/json',
+      },
     )
 
   def test_error_non_200_response(self):

--- a/test/adapter/sandbox_test.py
+++ b/test/adapter/sandbox_test.py
@@ -57,20 +57,44 @@ class SandboxAdapterTestCase(TestCase):
     other methods to control access (e.g., listen only on loopback
     interface, use IP address whitelist, etc.).
     """
-    # :todo: Implement test.
-    self.skipTest('Not implemented yet.')
+    # No access token.
+    adapter = SandboxAdapter('https://localhost', None)
 
-  def test_error_token_wrong_type(self):
+    expected_result = {
+      'message': 'Hello, IOTA!',
+    }
+
+    mocked_response = create_http_response(json.dumps(expected_result))
+    mocked_sender = Mock(return_value=mocked_response)
+
+    payload = {'command': 'helloWorld'}
+
+    # noinspection PyUnresolvedReferences
+    with patch.object(adapter, '_send_http_request', mocked_sender):
+      result = adapter.send_request(payload)
+
+    self.assertEqual(result, expected_result)
+
+    mocked_sender.assert_called_once_with(
+      payload = json.dumps(payload),
+
+      # No auth token, so no Authorization header.
+      # headers = {
+      #   'Authorization': 'token ACCESS-TOKEN',
+      # },
+    )
+
+  def test_error_auth_token_wrong_type(self):
     """
-    ``token`` is not a string.
+    ``auth_token`` is not a string.
     """
     with self.assertRaises(TypeError):
       # Nope; it has to be a unicode string.
       SandboxAdapter('https://localhost', b'not valid')
 
-  def test_error_token_empty(self):
+  def test_error_auth_token_empty(self):
     """
-    ``token`` is an empty string.
+    ``auth_token`` is an empty string.
     """
     with self.assertRaises(ValueError):
       # If the node does not require authorization, use ``None``.

--- a/test/adapter/wrappers_test.py
+++ b/test/adapter/wrappers_test.py
@@ -69,7 +69,7 @@ class RoutingWrapperTestCase(TestCase):
     )
 
     # Providing an adapter instance bypasses the whole setup.
-    wrapper1.add_route('delta', HttpAdapter('localhost', 14265))
+    wrapper1.add_route('delta', HttpAdapter('http://localhost:14265'))
     self.assertIsNot(
       wrapper1.get_adapter('delta'),
       wrapper1.get_adapter('alpha'),

--- a/test/adapter_test.py
+++ b/test/adapter_test.py
@@ -26,14 +26,14 @@ class ResolveAdapterTestCase(TestCase):
 
   def test_http(self):
     """
-    Resolving a valid `http://` URI.
+    Resolving a valid ``http://`` URI.
     """
     adapter = resolve_adapter('http://localhost:14265/')
     self.assertIsInstance(adapter, HttpAdapter)
 
   def test_https(self):
     """
-    Resolving a valid `https://` URI.
+    Resolving a valid ``https://`` URI.
     """
     adapter = resolve_adapter('https://localhost:14265/')
     self.assertIsInstance(adapter, HttpAdapter)
@@ -73,7 +73,7 @@ def create_http_response(content, status=200):
 class HttpAdapterTestCase(TestCase):
   def test_http(self):
     """
-    Configuring HttpAdapter using a valid http:// URI.
+    Configuring HttpAdapter using a valid ``http://`` URI.
     """
     uri     = 'http://localhost:14265/'
     adapter = HttpAdapter(uri)
@@ -82,7 +82,7 @@ class HttpAdapterTestCase(TestCase):
 
   def test_https(self):
     """
-    Configuring HttpAdapter using a valid https:// URI.
+    Configuring HttpAdapter using a valid ``https://`` URI.
     """
     uri     = 'https://localhost:14265/'
     adapter = HttpAdapter(uri)
@@ -338,4 +338,8 @@ class HttpAdapterTestCase(TestCase):
           'CCPCBDVC9DTCEAKDXC9D9DEARCWCPCBDVCTCEAHDWCTCEAKDCDFD9DSCSA',
         ],
       }),
+
+      headers = {
+        'Content-type': 'application/json',
+      },
     )

--- a/test/adapter_test.py
+++ b/test/adapter_test.py
@@ -53,22 +53,19 @@ class ResolveAdapterTestCase(TestCase):
       resolve_adapter('foobar://localhost:14265')
 
 
-def create_http_response(content):
-  # type: (Text) -> requests.Response
+def create_http_response(content, status=200):
+  # type: (Text, int) -> requests.Response
   """
   Creates an HTTP Response object for a test.
+
+  References:
+    - :py:meth:`requests.adapters.HTTPAdapter.build_response`
   """
-  # :py:meth:`requests.adapters.HTTPAdapter.build_response`
   response = requests.Response()
 
-  # Response status is always 200, even for an error.
-  # Note that this is fixed in later IRI implementations, but for
-  # backwards-compatibility, the adapter will ignore the status code.
-  # https://github.com/iotaledger/iri/issues/9
-  response.status_code = 200
-
-  response.encoding = 'utf-8'
-  response.raw = BytesIO(content.encode('utf-8'))
+  response.encoding     = 'utf-8'
+  response.status_code  = status
+  response.raw          = BytesIO(content.encode('utf-8'))
 
   return response
 
@@ -287,6 +284,8 @@ class HttpAdapterTestCase(TestCase):
       })
 
     mocked_sender.assert_called_once_with(
+      url = adapter.node_url,
+
       payload = json.dumps({
         'command': 'helloWorld',
 

--- a/test/adapter_test.py
+++ b/test/adapter_test.py
@@ -25,13 +25,6 @@ class ResolveAdapterTestCase(TestCase):
     adapter = MockAdapter()
     self.assertIs(resolve_adapter(adapter), adapter)
 
-  def test_udp(self):
-    """
-    Resolving a valid udp:// URI.
-    """
-    adapter = resolve_adapter('udp://localhost:14265/')
-    self.assertIsInstance(adapter, HttpAdapter)
-
   def test_http(self):
     """
     Resolving a valid http:// URI.
@@ -55,16 +48,6 @@ class ResolveAdapterTestCase(TestCase):
 
 
 class HttpAdapterTestCase(TestCase):
-  def test_configure_udp(self):
-    """
-    Configuring an HttpAdapter using a valid udp:// URI.
-    """
-    adapter = HttpAdapter.configure('udp://localhost:14265/')
-
-    self.assertEqual(adapter.host, 'localhost')
-    self.assertEqual(adapter.port, 14265)
-    self.assertEqual(adapter.path, '/')
-
   def test_configure_http(self):
     """
     Configuring HttpAdapter using a valid http:// URI.
@@ -79,20 +62,10 @@ class HttpAdapterTestCase(TestCase):
     """
     Configuring an HttpAdapter using an IPv4 address.
     """
-    adapter = HttpAdapter.configure('udp://127.0.0.1:8080/')
+    adapter = HttpAdapter.configure('http://127.0.0.1:8080/')
 
     self.assertEqual(adapter.host, '127.0.0.1')
     self.assertEqual(adapter.port, 8080)
-    self.assertEqual(adapter.path, '/')
-
-  def test_configure_default_port_udp(self):
-    """
-    Implicitly use default UDP port for HttpAdapter.
-    """
-    adapter = HttpAdapter.configure('udp://iotatoken.com/')
-
-    self.assertEqual(adapter.host, 'iotatoken.com')
-    self.assertEqual(adapter.port, DEFAULT_PORT)
     self.assertEqual(adapter.path, '/')
 
   def test_configure_default_port_http(self):
@@ -109,10 +82,10 @@ class HttpAdapterTestCase(TestCase):
     """
     Specifying a different path for HttpAdapter.
     """
-    adapter = HttpAdapter.configure('http://iotatoken.com:443/node')
+    adapter = HttpAdapter.configure('http://iotatoken.com:1024/node')
 
     self.assertEqual(adapter.host, 'iotatoken.com')
-    self.assertEqual(adapter.port, 443)
+    self.assertEqual(adapter.port, 1024)
     self.assertEqual(adapter.path, '/node')
 
   def test_configure_custom_path_default_port(self):
@@ -130,7 +103,7 @@ class HttpAdapterTestCase(TestCase):
     """
     Implicitly use default path for HttpAdapter.
     """
-    adapter = HttpAdapter.configure('udp://example.com:8000')
+    adapter = HttpAdapter.configure('http://example.com:8000')
 
     self.assertEqual(adapter.host, 'example.com')
     self.assertEqual(adapter.port, 8000)
@@ -140,10 +113,10 @@ class HttpAdapterTestCase(TestCase):
     """
     Implicitly use default port and path for HttpAdapter.
     """
-    adapter = HttpAdapter.configure('udp://localhost')
+    adapter = HttpAdapter.configure('http://localhost')
 
     self.assertEqual(adapter.host, 'localhost')
-    self.assertEqual(adapter.port, DEFAULT_PORT)
+    self.assertEqual(adapter.port, 80)
     self.assertEqual(adapter.path, '/')
 
   def test_configure_error_missing_protocol(self):
@@ -165,14 +138,21 @@ class HttpAdapterTestCase(TestCase):
     Attempting to configure HttpAdapter with empty host.
     """
     with self.assertRaises(InvalidUri):
-      HttpAdapter.configure('udp://:14265')
+      HttpAdapter.configure('http://:14265')
 
   def test_configure_error_non_numeric_port(self):
     """
     Attempting to configure HttpAdapter with non-numeric port.
     """
     with self.assertRaises(InvalidUri):
-      HttpAdapter.configure('udp://localhost:iota/')
+      HttpAdapter.configure('http://localhost:iota/')
+
+  def test_configure_error_udp(self):
+    """
+    UDP is not a valid protocol for ``HttpAdapter``.
+    """
+    with self.assertRaises(InvalidUri):
+      HttpAdapter.configure('udp://localhost:14265')
 
   def test_success_response(self):
     """

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -115,13 +115,23 @@ class IotaApiTestCase(TestCase):
     command = api.getNodeInfo
     self.assertIsInstance(command, GetNodeInfoCommand)
 
+  def test_unregistered_command(self):
+    """
+    Attempting to create an unsupported command.
+    """
+    api = StrictIota(MockAdapter())
+
+    with self.assertRaises(KeyError):
+      # noinspection PyStatementEffect
+      api.helloWorld
+
   def test_custom_command(self):
     """
     Preparing an experimental/undocumented command.
     """
     api = StrictIota(MockAdapter())
 
-    # We just need to make sure the correct command type is
-    # instantiated; custom commands have their own unit tests.
-    command = api.helloWorld
-    self.assertIsInstance(command, CustomCommand)
+    custom_command = api.custom_command('helloWorld')
+
+    self.assertIsInstance(custom_command, CustomCommand)
+    self.assertEqual(custom_command.command, 'helloWorld')

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, \
 
 from unittest import TestCase
 
-from iota import StrictIota
+from iota import InvalidCommand, StrictIota
 from iota.adapter import MockAdapter
 from iota.commands import CustomCommand
 from iota.commands.core.get_node_info import GetNodeInfoCommand
@@ -121,17 +121,17 @@ class IotaApiTestCase(TestCase):
     """
     api = StrictIota(MockAdapter())
 
-    with self.assertRaises(KeyError):
+    with self.assertRaises(InvalidCommand):
       # noinspection PyStatementEffect
       api.helloWorld
 
-  def test_custom_command(self):
+  def test_create_command(self):
     """
     Preparing an experimental/undocumented command.
     """
     api = StrictIota(MockAdapter())
 
-    custom_command = api.custom_command('helloWorld')
+    custom_command = api.create_command('helloWorld')
 
     self.assertIsInstance(custom_command, CustomCommand)
     self.assertEqual(custom_command.command, 'helloWorld')

--- a/test/commands/core/add_neighbors_test.py
+++ b/test/commands/core/add_neighbors_test.py
@@ -23,7 +23,7 @@ class AddNeighborsRequestFilterTestCase(BaseFilterTestCase):
     request = {
       'uris': [
         'udp://node1.iotatoken.com',
-        'http://localhost:14265/',
+        'udp://localhost:14265/',
       ],
     }
 
@@ -83,7 +83,7 @@ class AddNeighborsRequestFilterTestCase(BaseFilterTestCase):
       {
         # Nope; it's gotta be an array, even if you only want to add
         # a single neighbor.
-        'uris': 'http://localhost:8080/'
+        'uris': 'udp://localhost:8080/'
       },
 
       {
@@ -116,12 +116,15 @@ class AddNeighborsRequestFilterTestCase(BaseFilterTestCase):
           '',
           False,
           None,
-          b'http://localhost:8080/',
+          b'udp://localhost:8080/',
           'not a valid uri',
 
           # This is actually valid; I just added it to make sure the
           # filter isn't cheating!
-          'udp://localhost',
+          'udp://localhost:14265',
+
+          # Only UDP URIs are allowed.
+          'http://localhost:14265',
 
           2130706433,
         ],
@@ -133,7 +136,8 @@ class AddNeighborsRequestFilterTestCase(BaseFilterTestCase):
         'uris.2':  [f.Required.CODE_EMPTY],
         'uris.3':  [f.Type.CODE_WRONG_TYPE],
         'uris.4':  [NodeUri.CODE_NOT_NODE_URI],
-        'uris.6':  [f.Type.CODE_WRONG_TYPE],
+        'uris.6':  [NodeUri.CODE_NOT_NODE_URI],
+        'uris.7':  [f.Type.CODE_WRONG_TYPE],
       },
     )
 

--- a/test/commands/core/remove_neighbors_test.py
+++ b/test/commands/core/remove_neighbors_test.py
@@ -23,7 +23,7 @@ class RemoveNeighborsRequestFilterTestCase(BaseFilterTestCase):
     request = {
       'uris': [
         'udp://node1.iotatoken.com',
-        'http://localhost:14265/',
+        'udp://localhost:14265/',
       ],
     }
 
@@ -83,7 +83,7 @@ class RemoveNeighborsRequestFilterTestCase(BaseFilterTestCase):
       {
         # Nope; it's gotta be an array, even if you only want to add
         # a single neighbor.
-        'uris': 'http://localhost:8080/'
+        'uris': 'udp://localhost:8080/'
       },
 
       {
@@ -118,12 +118,15 @@ class RemoveNeighborsRequestFilterTestCase(BaseFilterTestCase):
           '',
           False,
           None,
-          b'http://localhost:8080/',
+          b'udp://localhost:8080/',
           'not a valid uri',
 
           # This is actually valid; I just added it to make sure the
           # filter isn't cheating!
           'udp://localhost',
+
+          # Only UDP URIs are allowed.
+          'http://localhost:14265',
 
           2130706433,
         ],
@@ -135,7 +138,8 @@ class RemoveNeighborsRequestFilterTestCase(BaseFilterTestCase):
         'uris.2':  [f.Required.CODE_EMPTY],
         'uris.3':  [f.Type.CODE_WRONG_TYPE],
         'uris.4':  [NodeUri.CODE_NOT_NODE_URI],
-        'uris.6':  [f.Type.CODE_WRONG_TYPE],
+        'uris.6':  [NodeUri.CODE_NOT_NODE_URI],
+        'uris.7':  [f.Type.CODE_WRONG_TYPE],
       },
     )
 

--- a/test/commands/extended/get_new_addresses_test.py
+++ b/test/commands/extended/get_new_addresses_test.py
@@ -311,7 +311,7 @@ class GetNewAddressesCommandTestCase(TestCase):
         seed  = b'TESTSEED9DONTUSEINPRODUCTION99999',
       )
 
-    self.assertListEqual(response, [self.addy1, self.addy2])
+    self.assertDictEqual(response, {'addresses': [self.addy1, self.addy2]})
 
     # No API requests were made.
     self.assertListEqual(self.adapter.requests, [])
@@ -359,7 +359,7 @@ class GetNewAddressesCommandTestCase(TestCase):
 
     # The command determined that ``self.addy1`` was already used, so
     # it skipped that one.
-    self.assertListEqual(response, [self.addy2])
+    self.assertDictEqual(response, {'addresses': [self.addy2]})
 
     self.assertListEqual(
       self.adapter.requests,

--- a/test/commands/extended/prepare_transfer_test.py
+++ b/test/commands/extended/prepare_transfer_test.py
@@ -2176,15 +2176,17 @@ class PrepareTransferCommandTestCase(TestCase):
     #   References:
     #     - :py:class:`iota.commands.extended.prepare_transfer.PrepareTransferCommand`
     #     - :py:class:`iota.commands.extended.get_new_addresses.GetNewAddressesCommand`
-    mock_get_new_addresses_command = Mock(return_value=[
-      Address(
-        trytes =
-          b'TESTVALUEFOUR9DONTUSEINPRODUCTION99999WJ'
-          b'RBOSBIMNTGDYKUDYYFJFGZOHORYSQPCWJRKHIOVIY',
+    mock_get_new_addresses_command = Mock(return_value={
+      'addresses': [
+        Address(
+          trytes =
+            b'TESTVALUEFOUR9DONTUSEINPRODUCTION99999WJ'
+            b'RBOSBIMNTGDYKUDYYFJFGZOHORYSQPCWJRKHIOVIY',
 
-        key_index = 5,
-      ),
-    ])
+          key_index = 5,
+        ),
+      ],
+    })
 
     self.adapter.seed_response('getBalances', {
       'balances': [86],


### PR DESCRIPTION
**IMPORTANT:** This version includes several changes that are not backwards-compatible with v1.0.x!

# Backwards-Incompatible Changes
- Dropped support for IRI nodes below v1.1.2.4.
- [#13] Removed support for `udp://` API URLs.  Use `http://` instead.
- `getNewAddresses` now returns a dict. All API commands now have consistent return types.
- Restricted which commands each API class can create (`StrictIota` can only create core commands; `Iota` can create core+extended).
    - `__getattr__` now raises an `InvalidCommand` error if an unsupported command is requested (previously it would return a `CustomCommand` instance).
    - Implemented `create_command` method to create `CustomCommand` objects.
- Removed `LogWrapper`.
    - To attach a logger to an adapter, invoke its (new) `set_logger` method.
    - Adapters will now log more information about HTTP requests, including URL and request/response headers.

# New Features
- [#19] Implemented support for sandbox nodes.

# Enhancements/Fixes
- [#6] `addNeighbors` and `removeNeighbors` now only accept `udp://` URIs.
- [#7] Added support for `https://` API URLs.
- Improved handling of non-200 responses from nodes.
- Adapters now use `urlsplit` to parse URIs.
- Adapters now provide more context vars when raising `BadApiResponse`.
- `discover_commands` now also returns all command objects that it finds.
- Changed `requests` dependency to `requests[security]`.
  - See https://github.com/kennethreitz/requests/issues/1995 for more info.
- Cleaned up code in `examples/shell.py`.
- General documentation cleanup and fixes.
