### PR TITLE
1.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: python
 python:
   - "2.7"
   - "3.5"
-  - "3.6-dev"
+  - "3.6"
 install: "pip install ."
 script: "nosetests"

--- a/examples/address_generator.py
+++ b/examples/address_generator.py
@@ -86,11 +86,11 @@ if __name__ == '__main__':
   parser.add_argument(
     '--uri',
       type    = text_type,
-      default = 'udp://localhost:14265/',
+      default = 'http://localhost:14265/',
 
       help =
         'URI of the node to connect to '
-        '(defaults to udp://localhost:14265/).',
+        '(defaults to http://localhost:14265/).',
   )
 
   parser.add_argument(

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -44,11 +44,11 @@ if __name__ == '__main__':
   parser.add_argument(
     '--uri',
       type    = text_type,
-      default = 'udp://localhost:14265/',
+      default = 'http://localhost:14265/',
 
       help =
         'URI of the node to connect to '
-        '(defaults to udp://localhost:14265/).',
+        '(defaults to http://localhost:14265/).',
   )
 
   main(**vars(parser.parse_args(argv[1:])))

--- a/examples/shell.py
+++ b/examples/shell.py
@@ -21,9 +21,6 @@ from iota.adapter import resolve_adapter
 from iota.adapter.wrappers import RoutingWrapper
 
 
-basicConfig(level=DEBUG, stream=stderr)
-
-
 def main(uri, testnet, pow_uri, debug_requests):
   # type: (Text, bool, Text, bool) -> None
   seed = secure_input(
@@ -47,8 +44,11 @@ def main(uri, testnet, pow_uri, debug_requests):
 
   # If ``debug_requests`` is specified, log HTTP requests/responses.
   if debug_requests:
+    basicConfig(level=DEBUG, stream=stderr)
+
     logger = getLogger(__name__)
     logger.setLevel(DEBUG)
+
     adapter_.set_logger(logger)
 
   iota = Iota(adapter_, seed=seed, testnet=testnet)

--- a/examples/shell.py
+++ b/examples/shell.py
@@ -19,6 +19,7 @@ from iota import *
 from iota import __version__
 from iota.adapter import resolve_adapter
 from iota.adapter.wrappers import RoutingWrapper
+from iota.crypto.addresses import AddressGenerator, MemoryAddressCache
 
 
 def main(uri, testnet, pow_uri, debug_requests):
@@ -52,6 +53,9 @@ def main(uri, testnet, pow_uri, debug_requests):
     adapter_.set_logger(logger)
 
   iota = Iota(adapter_, seed=seed, testnet=testnet)
+
+  # To speed up certain operations, install an address cache.
+  AddressGenerator.cache = MemoryAddressCache()
 
   _banner = (
     'IOTA API client for {uri} ({testnet}) initialized as variable `iota`.\n'

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
   name        = 'PyOTA',
   description = 'IOTA API library for Python',
   url         = 'https://github.com/iotaledger/iota.lib.py',
-  version     = '1.1.0',
+  version     = '1.1.1',
 
   packages              = find_packages('src'),
   include_package_data  = True,

--- a/setup.py
+++ b/setup.py
@@ -5,17 +5,8 @@
 from __future__ import absolute_import, division, print_function
 
 from codecs import StreamReader, open
-from sys import version_info
 
 from setuptools import find_packages, setup
-
-##
-# Check Python version.
-if version_info[0:2] < (2, 7):
-  raise EnvironmentError('PyOTA requires Python 2.7 or greater.')
-
-if (version_info[0] == 3) and (version_info[1] < 5):
-  raise EnvironmentError('PyOTA requires Python 3.5 or greater.')
 
 ##
 # Load long description for PyPi.
@@ -63,7 +54,9 @@ setup(
     'Topic :: Software Development :: Libraries :: Python Modules',
   ],
 
-  keywords = 'iota,tangle,iot,internet of things,api,library',
+  keywords =
+    'iota,tangle,iot,internet of things,api,library,cryptocurrency,'
+    'balanced ternary',
 
   author        = 'Phoenix Zerin',
   author_email  = 'phx@phx.ph',

--- a/src/iota/adapter/__init__.py
+++ b/src/iota/adapter/__init__.py
@@ -332,7 +332,11 @@ class HttpAdapter(BaseAdapter):
     raw_content = response.text
     if not raw_content:
       raise with_context(
-        exc = BadApiResponse('Empty response from node.'),
+        exc = BadApiResponse(
+          'Empty {status} response from node.'.format(
+            status = response.status_code,
+          ),
+        ),
 
         context = {
           'request': payload,
@@ -345,7 +349,8 @@ class HttpAdapter(BaseAdapter):
     except ValueError:
       raise with_context(
         exc = BadApiResponse(
-          'Non-JSON response from node: {raw_content}'.format(
+          'Non-JSON {status} response from node: {raw_content}'.format(
+            status      = response.status_code,
             raw_content = raw_content,
           )
         ),
@@ -359,7 +364,8 @@ class HttpAdapter(BaseAdapter):
     if not isinstance(decoded, dict):
       raise with_context(
         exc = BadApiResponse(
-          'Invalid response from node: {decoded!r}'.format(
+          'Malformed {status} response from node: {decoded!r}'.format(
+            status  = response.status_code,
             decoded = decoded,
           ),
         ),

--- a/src/iota/api.py
+++ b/src/iota/api.py
@@ -427,8 +427,8 @@ class Iota(StrictIota):
   def get_account_data(self, start=0, stop=None):
     # type± (int, Optional[int]) -> dict
     """
-    Returns all transfers to/from the account, as well as the
-    corresponding addresses and total account balance.
+    More comprehensive version of :py:meth:`get_transfers` that returns
+    addresses and account balance in addition to bundles.
 
     This function is useful in getting all the relevant information of
     your account.
@@ -455,9 +455,8 @@ class Iota(StrictIota):
            'balance': int,
              Total account balance.  Might be 0.
 
-           'transfers': List[Transaction],
-             List of transactions to/from this account.
-             Includes transactions with 0 value.
+           'bundles': List[Bundles],
+             List of bundles with transactions to/from this account.
          }
     """
     return self.getAccountData(

--- a/src/iota/api.py
+++ b/src/iota/api.py
@@ -424,6 +424,48 @@ class Iota(StrictIota):
     """
     return self.broadcastAndStore(trytes=trytes)
 
+  def get_account_data(self, start=0, stop=None):
+    # type± (int, Optional[int]) -> dict
+    """
+    Returns all transfers to/from the account, as well as the
+    corresponding addresses and total account balance.
+
+    This function is useful in getting all the relevant information of
+    your account.
+
+    :param start:
+      Starting key index.
+
+    :param stop:
+      Stop before this index.
+      Note that this parameter behaves like the ``stop`` attribute in a
+      :py:class:`slice` object; the stop index is *not* included in the
+      result.
+
+      If ``None`` (default), then this method will check every address
+      until it finds one without any transfers.
+
+    :return:
+      Dict containing the following values::
+
+         {
+           'addresses': List[Address],
+             List of addresses with transfers.
+
+           'balance': int,
+             Total account balance.  Might be 0.
+
+           'transfers': List[Transaction],
+             List of transactions to/from this account.
+             Includes transactions with 0 value.
+         }
+    """
+    return self.getAccountData(
+      seed  = self.seed,
+      start = start,
+      stop  = stop,
+    )
+
   def get_bundles(self, transaction):
     # type: (TransactionHash) -> dict
     """

--- a/src/iota/api.py
+++ b/src/iota/api.py
@@ -456,7 +456,8 @@ class Iota(StrictIota):
 
          {
            'addresses': List[Address],
-             List of addresses with transfers.
+             List of generated addresses.
+             Note that this list may include unused addresses.
 
            'balance': int,
              Total account balance.  Might be 0.

--- a/src/iota/api.py
+++ b/src/iota/api.py
@@ -424,8 +424,8 @@ class Iota(StrictIota):
     """
     return self.broadcastAndStore(trytes=trytes)
 
-  def get_account_data(self, start=0, stop=None):
-    # type± (int, Optional[int]) -> dict
+  def get_account_data(self, start=0, stop=None, inclusion_states=False):
+    # type± (int, Optional[int], bool) -> dict
     """
     More comprehensive version of :py:meth:`get_transfers` that returns
     addresses and account balance in addition to bundles.
@@ -445,6 +445,12 @@ class Iota(StrictIota):
       If ``None`` (default), then this method will check every address
       until it finds one without any transfers.
 
+    :param inclusion_states:
+      Whether to also fetch the inclusion states of the transfers.
+
+      This requires an additional API call to the node, so it is
+      disabled by default.
+
     :return:
       Dict containing the following values::
 
@@ -460,9 +466,10 @@ class Iota(StrictIota):
          }
     """
     return self.getAccountData(
-      seed  = self.seed,
-      start = start,
-      stop  = stop,
+      seed            = self.seed,
+      start           = start,
+      stop            = stop,
+      inclusionStates = inclusion_states,
     )
 
   def get_bundles(self, transaction):

--- a/src/iota/api.py
+++ b/src/iota/api.py
@@ -7,7 +7,8 @@ from typing import Dict, Iterable, Optional, Text
 from iota import AdapterSpec, Address, ProposedTransaction, Tag, \
   TransactionHash, TransactionTrytes, TryteString, TrytesCompatible
 from iota.adapter import BaseAdapter, resolve_adapter
-from iota.commands import BaseCommand, CustomCommand, discover_commands
+from iota.commands import BaseCommand, CustomCommand, core, \
+  discover_commands, extended
 from iota.crypto.types import Seed
 from six import with_metaclass
 
@@ -140,7 +141,7 @@ class StrictIota(with_metaclass(ApiMeta)):
     References:
       - https://iota.readme.io/docs/addneighors
     """
-    return self.addNeighbors(uris=uris)
+    return core.AddNeighborsCommand(self.adapter)(uris=uris)
 
   def attach_to_tangle(
       self,
@@ -167,7 +168,7 @@ class StrictIota(with_metaclass(ApiMeta)):
     if min_weight_magnitude is None:
       min_weight_magnitude = self.default_min_weight_magnitude
 
-    return self.attachToTangle(
+    return core.AttachToTangleCommand(self.adapter)(
       trunkTransaction    = trunk_transaction,
       branchTransaction   = branch_transaction,
       minWeightMagnitude  = min_weight_magnitude,
@@ -185,7 +186,7 @@ class StrictIota(with_metaclass(ApiMeta)):
     References:
       - https://iota.readme.io/docs/broadcasttransactions
     """
-    return self.broadcastTransactions(trytes=trytes)
+    return core.BroadcastTransactionsCommand(self.adapter)(trytes=trytes)
 
   def find_transactions(
       self,
@@ -220,7 +221,7 @@ class StrictIota(with_metaclass(ApiMeta)):
     References:
       - https://iota.readme.io/docs/findtransactions
     """
-    return self.findTransactions(
+    return core.FindTransactionsCommand(self.adapter)(
       bundles   = bundles,
       addresses = addresses,
       tags      = tags,
@@ -248,7 +249,7 @@ class StrictIota(with_metaclass(ApiMeta)):
     References:
       - https://iota.readme.io/docs/getbalances
     """
-    return self.getBalances(
+    return core.GetBalancesCommand(self.adapter)(
       addresses = addresses,
       threshold = threshold,
     )
@@ -271,7 +272,7 @@ class StrictIota(with_metaclass(ApiMeta)):
     References:
       - https://iota.readme.io/docs/getinclusionstates
     """
-    return self.getInclusionStates(
+    return core.GetInclusionStatesCommand(self.adapter)(
       transactions  = transactions,
       tips          = tips,
     )
@@ -287,7 +288,7 @@ class StrictIota(with_metaclass(ApiMeta)):
     References:
       - https://iota.readme.io/docs/getneighborsactivity
     """
-    return self.getNeighbors()
+    return core.GetNeighborsCommand(self.adapter)()
 
   def get_node_info(self):
     # type: () -> dict
@@ -297,7 +298,7 @@ class StrictIota(with_metaclass(ApiMeta)):
     References:
       - https://iota.readme.io/docs/getnodeinfo
     """
-    return self.getNodeInfo()
+    return core.GetNodeInfoCommand(self.adapter)()
 
   def get_tips(self):
     # type: () -> dict
@@ -309,7 +310,7 @@ class StrictIota(with_metaclass(ApiMeta)):
       - https://iota.readme.io/docs/gettips
       - https://iota.readme.io/docs/glossary#iota-terms
     """
-    return self.getTips()
+    return core.GetTipsCommand(self.adapter)()
 
   def get_transactions_to_approve(self, depth):
     # type: (int) -> dict
@@ -328,7 +329,7 @@ class StrictIota(with_metaclass(ApiMeta)):
     References:
       - https://iota.readme.io/docs/gettransactionstoapprove
     """
-    return self.getTransactionsToApprove(depth=depth)
+    return core.GetTransactionsToApproveCommand(self.adapter)(depth=depth)
 
   def get_trytes(self, hashes):
     # type: (Iterable[TransactionHash]) -> dict
@@ -339,7 +340,7 @@ class StrictIota(with_metaclass(ApiMeta)):
     References:
       - https://iota.readme.io/docs/gettrytes
     """
-    return self.getTrytes(hashes=hashes)
+    return core.GetTrytesCommand(self.adapter)(hashes=hashes)
 
   def interrupt_attaching_to_tangle(self):
     # type: () -> dict
@@ -350,7 +351,7 @@ class StrictIota(with_metaclass(ApiMeta)):
     References:
       - https://iota.readme.io/docs/interruptattachingtotangle
     """
-    return self.interruptAttachingToTangle()
+    return core.InterruptAttachingToTangleCommand(self.adapter)()
 
   def remove_neighbors(self, uris):
     # type: (Iterable[Text]) -> dict
@@ -365,7 +366,7 @@ class StrictIota(with_metaclass(ApiMeta)):
     References:
       - https://iota.readme.io/docs/removeneighors
     """
-    return self.removeNeighbors(uris=uris)
+    return core.RemoveNeighborsCommand(self.adapter)(uris=uris)
 
   def store_transactions(self, trytes):
     # type: (Iterable[TryteString]) -> dict
@@ -378,7 +379,7 @@ class StrictIota(with_metaclass(ApiMeta)):
     References:
       - https://iota.readme.io/docs/storetransactions
     """
-    return self.storeTransactions(trytes=trytes)
+    return core.StoreTransactionsCommand(self.adapter)(trytes=trytes)
 
 
 class Iota(StrictIota):
@@ -422,7 +423,7 @@ class Iota(StrictIota):
     References:
       - https://github.com/iotaledger/wiki/blob/master/api-proposal.md#broadcastandstore
     """
-    return self.broadcastAndStore(trytes=trytes)
+    return extended.BroadcastAndStoreCommand(self.adapter)(trytes=trytes)
 
   def get_account_data(self, start=0, stop=None, inclusion_states=False):
     # type± (int, Optional[int], bool) -> dict
@@ -466,7 +467,7 @@ class Iota(StrictIota):
              List of bundles with transactions to/from this account.
          }
     """
-    return self.getAccountData(
+    return extended.GetAccountDataCommand(self.adapter)(
       seed            = self.seed,
       start           = start,
       stop            = stop,
@@ -498,7 +499,7 @@ class Iota(StrictIota):
     References:
       - https://github.com/iotaledger/wiki/blob/master/api-proposal.md#getbundle
     """
-    return self.getBundles(transaction=transaction)
+    return extended.GetBundlesCommand(self.adapter)(transaction=transaction)
 
   def get_inputs(self, start=0, stop=None, threshold=None):
     # type: (int, Optional[int], Optional[int]) -> dict
@@ -570,7 +571,7 @@ class Iota(StrictIota):
     References:
       - https://github.com/iotaledger/wiki/blob/master/api-proposal.md#getinputs
     """
-    return self.getInputs(
+    return extended.GetInputsCommand(self.adapter)(
       seed      = self.seed,
       start     = start,
       stop      = stop,
@@ -596,7 +597,7 @@ class Iota(StrictIota):
            ...
          }
     """
-    return self.getLatestInclusion(hashes=hashes)
+    return extended.GetLatestInclusionCommand(self.adapter)(hashes=hashes)
 
   def get_new_addresses(self, index=0, count=1):
     # type: (int, Optional[int]) -> dict
@@ -626,7 +627,11 @@ class Iota(StrictIota):
     References:
       - https://github.com/iotaledger/wiki/blob/master/api-proposal.md#getnewaddress
     """
-    return self.getNewAddresses(seed=self.seed, index=index, count=count)
+    return extended.GetNewAddressesCommand(self.adapter)(
+      seed  = self.seed,
+      index = index,
+      count = count,
+    )
 
   def get_transfers(self, start=0, stop=None, inclusion_states=False):
     # type: (int, Optional[int], bool) -> dict
@@ -662,7 +667,7 @@ class Iota(StrictIota):
     References:
       - https://github.com/iotaledger/wiki/blob/master/api-proposal.md#gettransfers
     """
-    return self.getTransfers(
+    return extended.GetTransfersCommand(self.adapter)(
       seed            = self.seed,
       start           = start,
       stop            = stop,
@@ -706,7 +711,7 @@ class Iota(StrictIota):
     References:
       - https://github.com/iotaledger/wiki/blob/master/api-proposal.md#preparetransfers
     """
-    return self.prepareTransfer(
+    return extended.PrepareTransferCommand(self.adapter)(
       seed          = self.seed,
       transfers     = transfers,
       inputs        = inputs,
@@ -751,7 +756,7 @@ class Iota(StrictIota):
     if min_weight_magnitude is None:
       min_weight_magnitude = self.default_min_weight_magnitude
 
-    return self.replayBundle(
+    return extended.ReplayBundleCommand(self.adapter)(
       transaction         = transaction,
       depth               = depth,
       minWeightMagnitude  = min_weight_magnitude,
@@ -808,7 +813,7 @@ class Iota(StrictIota):
     if min_weight_magnitude is None:
       min_weight_magnitude = self.default_min_weight_magnitude
 
-    return self.sendTransfer(
+    return extended.SendTransferCommand(self.adapter)(
       seed                = self.seed,
       depth               = depth,
       transfers           = transfers,
@@ -846,7 +851,7 @@ class Iota(StrictIota):
     References:
       - https://github.com/iotaledger/wiki/blob/master/api-proposal.md#sendtrytes
     """
-    return self.sendTrytes(
+    return extended.SendTrytesCommand(self.adapter)(
       trytes              = trytes,
       depth               = depth,
       minWeightMagnitude  = min_weight_magnitude,

--- a/src/iota/commands/core/__init__.py
+++ b/src/iota/commands/core/__init__.py
@@ -8,3 +8,19 @@ References:
 
 from __future__ import absolute_import, division, print_function, \
   unicode_literals
+
+
+from .add_neighbors import *
+from .attach_to_tangle import *
+from .broadcast_transactions import *
+from .find_transactions import *
+from .get_balances import *
+from .get_inclusion_states import *
+from .get_neighbors import *
+from .get_node_info import *
+from .get_tips import *
+from .get_transactions_to_approve import *
+from .get_trytes import *
+from .interrupt_attaching_to_tangle import *
+from .remove_neighbors import *
+from .store_transactions import *

--- a/src/iota/commands/core/find_transactions.py
+++ b/src/iota/commands/core/find_transactions.py
@@ -91,8 +91,9 @@ class FindTransactionsResponseFilter(ResponseFilter):
   def __init__(self):
     super(FindTransactionsResponseFilter, self).__init__({
       'hashes':
-        f.FilterRepeater(
-            f.ByteString(encoding='ascii')
-          | Trytes(result_type=TransactionHash)
-        ),
+          f.FilterRepeater(
+              f.ByteString(encoding='ascii')
+            | Trytes(result_type=TransactionHash)
+          )
+        | f.Optional(default=[]),
     })

--- a/src/iota/commands/core/remove_neighbors.py
+++ b/src/iota/commands/core/remove_neighbors.py
@@ -7,6 +7,10 @@ import filters as f
 from iota.commands import FilterCommand, RequestFilter
 from iota.filters import NodeUri
 
+__all__ = [
+  'RemoveNeighborsCommand',
+]
+
 
 class RemoveNeighborsCommand(FilterCommand):
   """

--- a/src/iota/commands/extended/__init__.py
+++ b/src/iota/commands/extended/__init__.py
@@ -9,3 +9,16 @@ References:
 
 from __future__ import absolute_import, division, print_function, \
   unicode_literals
+
+
+from .broadcast_and_store import *
+from .get_account_data import *
+from .get_bundles import *
+from .get_inputs import *
+from .get_latest_inclusion import *
+from .get_new_addresses import *
+from .get_transfers import *
+from .prepare_transfer import *
+from .replay_bundle import *
+from .send_transfer import *
+from .send_trytes import *

--- a/src/iota/commands/extended/broadcast_and_store.py
+++ b/src/iota/commands/extended/broadcast_and_store.py
@@ -14,9 +14,9 @@ __all__ = [
 
 class BroadcastAndStoreCommand(FilterCommand):
   """
-  Executes `broadcastAndStore` extended API command.
+  Executes ``broadcastAndStore`` extended API command.
 
-  See :py:meth:`iota.api.IotaApi.broadcast_and_store` for more info.
+  See :py:meth:`iota.api.Iota.broadcast_and_store` for more info.
   """
   command = 'broadcastAndStore'
 

--- a/src/iota/commands/extended/get_account_data.py
+++ b/src/iota/commands/extended/get_account_data.py
@@ -1,0 +1,27 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, \
+  unicode_literals
+
+from iota.commands import FilterCommand
+
+__all__ = [
+  'GetAccountDataCommand',
+]
+
+
+class GetAccountDataCommand(FilterCommand):
+  """
+  Executes ``getAccountData`` extended API command.
+
+  See :py:meth:`iota.api.Iota.get_account_data` for more info.
+  """
+  command = 'getAccountData'
+
+  def get_request_filter(self):
+    pass
+
+  def get_response_filter(self):
+    pass
+
+  def _execute(self, request):
+    pass

--- a/src/iota/commands/extended/get_account_data.py
+++ b/src/iota/commands/extended/get_account_data.py
@@ -2,7 +2,13 @@
 from __future__ import absolute_import, division, print_function, \
   unicode_literals
 
-from iota.commands import FilterCommand
+from typing import Optional
+
+import filters as f
+
+from iota.commands import FilterCommand, RequestFilter
+from iota.crypto.types import Seed
+from iota.filters import Trytes
 
 __all__ = [
   'GetAccountDataCommand',
@@ -18,10 +24,86 @@ class GetAccountDataCommand(FilterCommand):
   command = 'getAccountData'
 
   def get_request_filter(self):
-    pass
+    return GetAccountDataRequestFilter()
 
   def get_response_filter(self):
     pass
 
   def _execute(self, request):
-    pass
+    seed              = request['seed'] # type: Seed
+    start             = request['start'] # type: int
+    stop              = request['stop'] # type: Optional[int]
+    inclusion_states  = request['inclusionStates'] # type: bool
+
+    raise NotImplementedError(
+      'Not implemented in {cls}.'.format(cls=type(self).__name__),
+    )
+
+
+class GetAccountDataRequestFilter(RequestFilter):
+  MAX_INTERVAL = 500
+
+  CODE_INTERVAL_INVALID = 'interval_invalid'
+  CODE_INTERVAL_TOO_BIG = 'interval_too_big'
+
+  templates = {
+    CODE_INTERVAL_INVALID: '``start`` must be <= ``stop``',
+    CODE_INTERVAL_TOO_BIG: '``stop`` - ``start`` must be <= {max_interval}',
+  }
+
+  def __init__(self):
+    super(GetAccountDataRequestFilter, self).__init__(
+      {
+        # Required parameters.
+        'seed': f.Required | Trytes(result_type=Seed),
+
+        # Optional parameters.
+        'stop':   f.Type(int) | f.Min(0),
+        'start':  f.Type(int) | f.Min(0) | f.Optional(0),
+
+        'inclusionStates': f.Type(bool) | f.Optional(False),
+      },
+
+      allow_missing_keys = {
+        'stop',
+        'inclusionStates',
+        'start',
+      },
+    )
+
+  def _apply(self, value):
+    # noinspection PyProtectedMember
+    filtered = super(GetAccountDataRequestFilter, self)._apply(value)
+
+    if self._has_errors:
+      return filtered
+
+    if filtered['stop'] is not None:
+      if filtered['start'] > filtered['stop']:
+        filtered['start'] = self._invalid_value(
+          value   = filtered['start'],
+          reason  = self.CODE_INTERVAL_INVALID,
+          sub_key = 'start',
+
+          context = {
+            'start':  filtered['start'],
+            'stop':   filtered['stop'],
+          },
+        )
+      elif (filtered['stop'] - filtered['start']) > self.MAX_INTERVAL:
+        filtered['stop'] = self._invalid_value(
+          value   = filtered['stop'],
+          reason  = self.CODE_INTERVAL_TOO_BIG,
+          sub_key = 'stop',
+
+          context = {
+            'start':  filtered['start'],
+            'stop':   filtered['stop'],
+          },
+
+          template_vars = {
+            'max_interval': self.MAX_INTERVAL,
+          },
+        )
+
+    return filtered

--- a/src/iota/commands/extended/get_inputs.py
+++ b/src/iota/commands/extended/get_inputs.py
@@ -57,8 +57,11 @@ class GetInputsCommand(FilterCommand):
     else:
       addresses = generator.get_addresses(start, stop)
 
-    # Load balances for the addresses that we generated.
-    gb_response = GetBalancesCommand(self.adapter)(addresses=addresses)
+    if addresses:
+      # Load balances for the addresses that we generated.
+      gb_response = GetBalancesCommand(self.adapter)(addresses=addresses)
+    else:
+      gb_response = {'balances': []}
 
     result = {
       'inputs': [],

--- a/src/iota/commands/extended/get_new_addresses.py
+++ b/src/iota/commands/extended/get_new_addresses.py
@@ -2,11 +2,10 @@
 from __future__ import absolute_import, division, print_function, \
   unicode_literals
 
-from typing import List, Optional
+from typing import Optional
 
 import filters as f
 
-from iota import Address
 from iota.commands import FilterCommand, RequestFilter
 from iota.commands.core.find_transactions import FindTransactionsCommand
 from iota.crypto.addresses import AddressGenerator

--- a/src/iota/commands/extended/get_new_addresses.py
+++ b/src/iota/commands/extended/get_new_addresses.py
@@ -51,7 +51,7 @@ class GetNewAddressesCommand(FilterCommand):
     if count is None:
       # Connect to Tangle and find the first address without any
       # transactions.
-      for addy in generator.create_generator(start=index):
+      for addy in generator.create_iterator(start=index):
         response = FindTransactionsCommand(self.adapter)(addresses=[addy])
 
         if not response.get('hashes'):

--- a/src/iota/commands/extended/utils.py
+++ b/src/iota/commands/extended/utils.py
@@ -1,0 +1,137 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, \
+  unicode_literals
+
+from typing import Generator, Iterable, List, Tuple
+
+from iota import Address, Bundle, Transaction, \
+  TransactionHash
+from iota.adapter import BaseAdapter
+from iota.commands.core.find_transactions import FindTransactionsCommand
+from iota.commands.core.get_trytes import GetTrytesCommand
+from iota.commands.extended.get_bundles import GetBundlesCommand
+from iota.commands.extended.get_latest_inclusion import \
+  GetLatestInclusionCommand
+from iota.crypto.addresses import AddressGenerator
+from iota.crypto.types import Seed
+
+
+def find_transaction_objects(adapter, **kwargs):
+    # type: (BaseAdapter, dict) -> List[Transaction]
+    """
+    Finds transactions matching the specified criteria, fetches the
+    corresponding trytes and converts them into Transaction objects.
+    """
+    ft_response = FindTransactionsCommand(adapter)(**kwargs)
+
+    hashes = ft_response['hashes']
+
+    if hashes:
+      gt_response = GetTrytesCommand(adapter)(hashes=hashes)
+
+      return list(map(
+        Transaction.from_tryte_string,
+        gt_response.get('trytes') or [],
+      )) # type: List[Transaction]
+
+    return []
+
+
+def iter_used_addresses(adapter, seed, start):
+  # type: (BaseAdapter, Seed, int) -> Generator[Tuple[Address, List[TransactionHash]]]
+  """
+  Scans the Tangle for used addresses.
+
+  This is basically the opposite of invoking ``getNewAddresses`` with
+  ``stop=None``.
+  """
+  ft_command = FindTransactionsCommand(adapter)
+
+  for addy in AddressGenerator(seed).create_iterator(start):
+    ft_response = ft_command(addresses=[addy])
+
+    if ft_response['hashes']:
+      yield addy, ft_response['hashes']
+    else:
+      break
+
+    # Reset the command so that we can call it again.
+    ft_command.reset()
+
+
+def get_bundles_from_transaction_hashes(
+    adapter,
+    transaction_hashes,
+    inclusion_states,
+):
+  # type: (BaseAdapter, Iterable[TransactionHash], bool) -> List[Bundle]
+  """
+  Given a set of transaction hashes, returns the corresponding bundles,
+  sorted by tail transaction timestamp.
+  """
+  transaction_hashes = list(transaction_hashes)
+  if not transaction_hashes:
+    return []
+
+  my_bundles = [] # type: List[Bundle]
+
+  # Sort transactions into tail and non-tail.
+  tail_transaction_hashes = set()
+  non_tail_bundle_hashes  = set()
+
+  gt_response = GetTrytesCommand(adapter)(hashes=transaction_hashes)
+  all_transactions = list(map(
+    Transaction.from_tryte_string,
+    gt_response['trytes'],
+  )) # type: List[Transaction]
+
+  for txn in all_transactions:
+    if txn.is_tail:
+      tail_transaction_hashes.add(txn.hash)
+    else:
+      # Capture the bundle ID instead of the transaction hash so that
+      # we can query the node to find the tail transaction for that
+      # bundle.
+      non_tail_bundle_hashes.add(txn.bundle_hash)
+
+  if non_tail_bundle_hashes:
+    for txn in find_transaction_objects(
+        adapter = adapter,
+        bundles = list(non_tail_bundle_hashes)
+    ):
+      if txn.is_tail:
+        if txn.hash not in tail_transaction_hashes:
+          all_transactions.append(txn)
+          tail_transaction_hashes.add(txn.hash)
+
+  # Filter out all non-tail transactions.
+  tail_transactions = [
+    txn
+      for txn in all_transactions
+      if txn.hash in tail_transaction_hashes
+  ]
+
+  # Attach inclusion states, if requested.
+  if inclusion_states:
+    gli_response = GetLatestInclusionCommand(adapter)(
+      hashes = list(tail_transaction_hashes),
+    )
+
+    for txn in tail_transactions:
+      txn.is_confirmed = gli_response['states'].get(txn.hash)
+
+  # Find the bundles for each transaction.
+  for txn in tail_transactions:
+    gb_response = GetBundlesCommand(adapter)(transaction=txn.hash)
+    txn_bundles = gb_response['bundles'] # type: List[Bundle]
+
+    if inclusion_states:
+      for bundle in txn_bundles:
+        bundle.is_confirmed = txn.is_confirmed
+
+    my_bundles.extend(txn_bundles)
+
+  return list(sorted(
+    my_bundles,
+      key = lambda bundle_: bundle_.tail_transaction.timestamp,
+  ))

--- a/src/iota/crypto/addresses.py
+++ b/src/iota/crypto/addresses.py
@@ -108,7 +108,7 @@ class AddressGenerator(Iterable[Address]):
     Returns a generator for creating new addresses, starting at index
     0 and potentially continuing on forever.
     """
-    return self.create_generator()
+    return self.create_iterator()
 
   def get_addresses(self, start, count=1, step=1):
     # type: (int, int, int) -> List[Address]
@@ -118,7 +118,7 @@ class AddressGenerator(Iterable[Address]):
 
     This is a one-time operation; if you want to create lots of
     addresses across multiple contexts, consider invoking
-    :py:meth:`create_generator` and sharing the resulting generator
+    :py:meth:`create_iterator` and sharing the resulting generator
     object instead.
 
     Warning: This method may take awhile to run if the starting index
@@ -165,7 +165,7 @@ class AddressGenerator(Iterable[Address]):
         },
       )
 
-    generator = self.create_generator(start, step)
+    generator = self.create_iterator(start, step)
 
     addresses = []
     for _ in range(count):
@@ -178,10 +178,10 @@ class AddressGenerator(Iterable[Address]):
 
     return addresses
 
-  def create_generator(self, start=0, step=1):
+  def create_iterator(self, start=0, step=1):
     # type: (int, int) -> Generator[Address]
     """
-    Creates a generator that can be used to progressively generate new
+    Creates an iterator that can be used to progressively generate new
     addresses.
 
     :param start:

--- a/src/iota/crypto/addresses.py
+++ b/src/iota/crypto/addresses.py
@@ -2,17 +2,67 @@
 from __future__ import absolute_import, division, print_function, \
   unicode_literals
 
-from typing import Generator, Iterable, List, MutableSequence
+from abc import ABCMeta, abstractmethod as abstract_method
+from collections import defaultdict
+from typing import Dict, Generator, Iterable, List, MutableSequence, Optional
 
-from iota import Address, TRITS_PER_TRYTE, TryteString, TrytesCompatible
+from six import with_metaclass
+
+from iota import Address, TRITS_PER_TRYTE, TrytesCompatible
 from iota.crypto import Curl
-from iota.crypto.signing import KeyGenerator
-from iota.crypto.types import PrivateKey
+from iota.crypto.signing import KeyGenerator, KeyIterator
+from iota.crypto.types import PrivateKey, Seed
 from iota.exceptions import with_context
 
 __all__ = [
   'AddressGenerator',
+  'MemoryAddressCache',
 ]
+
+
+class BaseAddressCache(with_metaclass(ABCMeta)):
+  """
+  Base functionality for classes that cache generated addresses.
+  """
+  @abstract_method
+  def get(self, seed, index):
+    # type: (Seed, int) -> Optional[Address]
+    """
+    Retrieves an address from the cache.
+    Returns ``None`` if the address hasn't been cached yet.
+    """
+    raise NotImplementedError(
+      'Not implemented in {cls}.'.format(cls=type(self).__name__),
+    )
+
+  @abstract_method
+  def set(self, seed, index, address):
+    # type: (Seed, int, Address) -> None
+    """
+    Adds an address to the cache, overwriting the existing address if
+    set.
+    """
+    raise NotImplementedError(
+      'Not implemented in {cls}.'.format(cls=type(self).__name__),
+    )
+
+
+class MemoryAddressCache(BaseAddressCache):
+  """
+  Caches addresses in memory.
+  """
+  def __init__(self):
+    super(MemoryAddressCache, self).__init__()
+
+    self.cache = defaultdict(dict) # type: Dict[Seed, Dict[int, Address]]
+
+  def get(self, seed, index):
+    # type: (Seed, int) -> Optional[Address]
+    return self.cache[seed].get(index)
+
+  def set(self, seed, index, address):
+    # type: (Seed, int, Address) -> None
+    self.cache[seed][index] = address
 
 
 class AddressGenerator(Iterable[Address]):
@@ -40,11 +90,17 @@ class AddressGenerator(Iterable[Address]):
     - :py:class:`iota.transaction.BundleValidator`
   """
 
+  cache = None # type: BaseAddressCache
+  """
+  Set a the instance or class level to inject a cache into the address
+  generation process.
+  """
+
   def __init__(self, seed):
     # type: (TrytesCompatible) -> None
     super(AddressGenerator, self).__init__()
 
-    self.seed = TryteString(seed)
+    self.seed = Seed(seed)
 
   def __iter__(self):
     # type: () -> Generator[Address]
@@ -140,27 +196,26 @@ class AddressGenerator(Iterable[Address]):
       Warning: The generator may take awhile to advance between
       iterations if ``step`` is a large number!
     """
-    if start < 0:
-      raise with_context(
-        exc = ValueError('``start`` cannot be negative.'),
+    key_iterator = (
+      KeyGenerator(self.seed)
+        .create_iterator(start, step, iterations=self.DIGEST_ITERATIONS)
+    )
 
-        context = {
-          'start':  start,
-          'step':   step,
-        },
-      )
+    while True:
+      if self.cache:
+        address = self.cache.get(self.seed, key_iterator.current)
 
-    digest_generator = self._create_digest_generator(start, step)
+        if not address:
+          address = self._generate_address(key_iterator)
+          self.cache.set(self.seed, address.key_index, address)
+      else:
+        address = self._generate_address(key_iterator)
 
-    current = start
-
-    while current >= 0:
-      yield self.address_from_digest(next(digest_generator), current)
-      current += step
+      yield address
 
   @staticmethod
   def address_from_digest(digest_trits, key_index):
-    # type: (Iterable[int], int) -> Address
+    # type: (List[int], int) -> Address
     """
     Generates an address from a private key digest.
     """
@@ -172,21 +227,26 @@ class AddressGenerator(Iterable[Address]):
 
     address = Address.from_trits(address_trits)
     address.key_index = key_index
+
     return address
 
-  def _create_digest_generator(self, start, step):
-    # type: (int, int) -> Generator[List[int]]
+  def _generate_address(self, key_iterator):
+    # type: (KeyIterator) -> Address
     """
-    Initializes a generator to create PrivateKey digests.
+    Generates a new address.
 
-    Implemented as a separate method so that it can be mocked during
-    unit tests.
+    Used in the event of a cache miss.
     """
-    key_generator = (
-      KeyGenerator(self.seed)
-        .create_generator(start, step, iterations=self.DIGEST_ITERATIONS)
-    )
+    return self.address_from_digest(*self._get_digest_params(key_iterator))
 
-    while True:
-      private_key = next(key_generator) # type: PrivateKey
-      yield private_key.get_digest_trits()
+  @staticmethod
+  def _get_digest_params(key_iterator):
+    # type: (KeyIterator) -> Tuple[List[int], int]
+    """
+    Extracts parameters for :py:meth:`address_from_digest`.
+
+    Split into a separate method so that it can be mocked during unit
+    tests.
+    """
+    private_key = next(key_iterator) # type: PrivateKey
+    return private_key.get_digest_trits(), private_key.key_index

--- a/src/iota/crypto/addresses.py
+++ b/src/iota/crypto/addresses.py
@@ -188,5 +188,5 @@ class AddressGenerator(Iterable[Address]):
     )
 
     while True:
-      signing_key = next(key_generator) # type: PrivateKey
-      yield signing_key.get_digest_trits()
+      private_key = next(key_generator) # type: PrivateKey
+      yield private_key.get_digest_trits()

--- a/src/iota/crypto/signing.py
+++ b/src/iota/crypto/signing.py
@@ -76,7 +76,7 @@ class KeyGenerator(object):
 
     This is a one-time operation; if you want to create lots of keys
     across multiple contexts, consider invoking
-    :py:meth:`create_generator` and sharing the resulting generator
+    :py:meth:`create_iterator` and sharing the resulting generator
     object instead.
 
     Warning: This method may take awhile to run if the starting index

--- a/src/iota/crypto/types.py
+++ b/src/iota/crypto/types.py
@@ -87,12 +87,12 @@ class PrivateKey(TryteString):
     """
     hashes_per_fragment = FRAGMENT_LENGTH // Hash.LEN
 
-    key_chunks = self.iter_chunks(FRAGMENT_LENGTH)
+    key_fragments = self.iter_chunks(FRAGMENT_LENGTH)
 
     # The digest will contain one hash per key fragment.
-    digest = [0] * HASH_LENGTH * len(key_chunks)
+    digest = [0] * HASH_LENGTH * len(key_fragments)
 
-    for (i, fragment) in enumerate(key_chunks): # type: Tuple[int, TryteString]
+    for (i, fragment) in enumerate(key_fragments): # type: Tuple[int, TryteString]
       fragment_trits = fragment.as_trits()
 
       key_fragment  = [0] * FRAGMENT_LENGTH

--- a/src/iota/json.py
+++ b/src/iota/json.py
@@ -24,6 +24,29 @@ class JsonSerializable(with_metaclass(ABCMeta)):
       'Not implemented in {cls}.'.format(cls=type(self).__name__),
     )
 
+  def _repr_pretty_(self, p, cycle):
+    """
+    Makes JSON-serializable objects play nice with IPython's default
+    pretty-printer.
+
+    Sadly, :py:func:`pprint.pprint` does not have a similar mechanism.
+
+    References:
+      - http://ipython.readthedocs.io/en/stable/api/generated/IPython.lib.pretty.html
+      - :py:meth:`IPython.lib.pretty.RepresentationPrinter.pretty`
+      - :py:func:`pprint._safe_repr`
+    """
+    # type: (JsonSerializable, bool) -> Text
+    class_name = type(self).__name__
+
+    if cycle:
+      p.text('{cls}(...)'.format(
+        cls = class_name,
+      ))
+    else:
+      with p.group(len(class_name)+1, '{cls}('.format(cls=class_name), ')'):
+        p.pretty(self.as_json_compatible())
+
 
 # noinspection PyClassHasNoInit
 class JsonEncoder(BaseJsonEncoder):

--- a/src/iota/types.py
+++ b/src/iota/types.py
@@ -249,7 +249,7 @@ class TryteString(JsonSerializable):
   def __bytes__(self):
     # type: () -> binary_type
     """
-    Converts the TryteString into a string representation.
+    Converts the TryteString into a bytestring representation.
 
     Note that this method will NOT convert the trytes back into bytes;
     use :py:meth:`as_bytes` for that.
@@ -260,8 +260,8 @@ class TryteString(JsonSerializable):
     # type: () -> bool
     return bool(self._trytes) and any(t != b'9' for t in self)
 
-  # :bc: Magic methods have different names in Python 2.
   if PY2:
+    # Magic methods have different names in Python 2.
     __nonzero__ = __bool__
     __str__     = __bytes__
 

--- a/src/iota/types.py
+++ b/src/iota/types.py
@@ -506,6 +506,20 @@ class TryteString(JsonSerializable):
     # http://stackoverflow.com/a/952952/5568265#comment4204394_952952
     return list(chain.from_iterable(self.as_trytes()))
 
+  def _repr_pretty_(self, p, cycle):
+    """
+    Makes JSON-serializable objects play nice with IPython's default
+    pretty-printer.
+
+    Sadly, :py:func:`pprint.pprint` does not have a similar mechanism.
+
+    References:
+      - http://ipython.readthedocs.io/en/stable/api/generated/IPython.lib.pretty.html
+      - :py:meth:`IPython.lib.pretty.RepresentationPrinter.pretty`
+      - :py:func:`pprint._safe_repr`
+    """
+    return p.text(repr(self))
+
   @staticmethod
   def _normalize(n):
     # type: (int) -> int

--- a/test/adapter_test.py
+++ b/test/adapter_test.py
@@ -254,7 +254,10 @@ class HttpAdapterTestCase(TestCase):
       with self.assertRaises(BadApiResponse) as context:
         adapter.send_request({'command': 'helloWorld'})
 
-    self.assertEqual(text_type(context.exception), 'Empty response from node.')
+    self.assertEqual(
+      text_type(context.exception),
+      'Empty 200 response from node.',
+    )
 
   def test_non_json_response(self):
     """
@@ -274,7 +277,7 @@ class HttpAdapterTestCase(TestCase):
 
     self.assertEqual(
       text_type(context.exception),
-      'Non-JSON response from node: ' + invalid_response,
+      'Non-JSON 200 response from node: ' + invalid_response,
     )
 
   def test_non_object_response(self):
@@ -296,7 +299,7 @@ class HttpAdapterTestCase(TestCase):
     self.assertEqual(
       text_type(context.exception),
 
-      'Invalid response from node: {response!r}'.format(
+      'Malformed 200 response from node: {response!r}'.format(
         response = invalid_response,
       ),
     )

--- a/test/commands/extended/broadcast_and_store_test.py
+++ b/test/commands/extended/broadcast_and_store_test.py
@@ -14,6 +14,8 @@ from iota.commands.extended.broadcast_and_store import BroadcastAndStoreCommand
 class BroadcastAndStoreCommandTestCase(TestCase):
   # noinspection SpellCheckingInspection
   def setUp(self):
+    super(BroadcastAndStoreCommandTestCase, self).setUp()
+
     self.adapter = MockAdapter()
     self.command = BroadcastAndStoreCommand(self.adapter)
 

--- a/test/commands/extended/get_account_data_test.py
+++ b/test/commands/extended/get_account_data_test.py
@@ -4,16 +4,338 @@ from __future__ import absolute_import, division, print_function, \
 
 from unittest import TestCase
 
-from iota import Iota
+import filters as f
+from filters.test import BaseFilterTestCase
+from iota import Address, Bundle, BundleHash, Fragment, Hash, Iota, Tag, \
+  Transaction, TransactionHash
 from iota.adapter import MockAdapter
-from iota.commands.extended.get_account_data import GetAccountDataCommand
+from iota.commands.extended.get_account_data import GetAccountDataCommand, \
+  GetAccountDataRequestFilter
+from iota.crypto.types import Seed
+from iota.filters import Trytes
+from mock import Mock
+from six import binary_type, text_type
+
+
+class GetAccountDataRequestFilterTestCase(BaseFilterTestCase):
+  filter_type = GetAccountDataCommand(MockAdapter()).get_request_filter
+  skip_value_check = True
+
+  # noinspection SpellCheckingInspection
+  def setUp(self):
+    super(GetAccountDataRequestFilterTestCase, self).setUp()
+
+    # Define a few tryte sequences that we can re-use between tests.
+    self.seed = b'HELLOIOTA'
+
+  def test_pass_happy_path(self):
+    """
+    Request is valid.
+    """
+    request = {
+      'seed':             Seed(self.seed),
+      'start':            0,
+      'stop':             10,
+      'inclusionStates':  True,
+    }
+
+    filter_ = self._filter(request)
+
+    self.assertFilterPasses(filter_)
+    self.assertDictEqual(filter_.cleaned_data, request)
+
+  def test_pass_compatible_types(self):
+    """
+    The request contains values that can be converted to the expected
+    types.
+    """
+    filter_ = self._filter({
+      # ``seed`` can be any value that is convertible into a
+      # TryteString.
+      'seed': binary_type(self.seed),
+
+      # These values must still be integers/bools, however.
+      'start':            42,
+      'stop':             86,
+      'inclusionStates':  True,
+    })
+
+    self.assertFilterPasses(filter_)
+    self.assertDictEqual(
+      filter_.cleaned_data,
+
+      {
+        'seed':             Seed(self.seed),
+        'start':            42,
+        'stop':             86,
+        'inclusionStates':  True,
+      },
+    )
+
+  def test_pass_optional_parameters_excluded(self):
+    """
+    The request contains only required parameters.
+    """
+    filter_ = self._filter({
+      'seed': Seed(self.seed),
+    })
+
+    self.assertFilterPasses(filter_)
+    self.assertDictEqual(
+      filter_.cleaned_data,
+
+      {
+        'seed':             Seed(self.seed),
+        'start':            0,
+        'stop':             None,
+        'inclusionStates':  False,
+      }
+    )
+
+  def test_fail_empty_request(self):
+    """
+    The request is empty.
+    """
+    self.assertFilterErrors(
+      {},
+
+      {
+        'seed': [f.FilterMapper.CODE_MISSING_KEY],
+      },
+    )
+
+  def test_fail_unexpected_parameters(self):
+    """
+    The request contains unexpected parameters.
+    """
+    self.assertFilterErrors(
+      {
+        'seed': Seed(self.seed),
+
+        # Your rules are really beginning to annoy me.
+        'foo': 'bar',
+      },
+
+      {
+        'foo': [f.FilterMapper.CODE_EXTRA_KEY],
+      },
+    )
+
+  def test_fail_seed_null(self):
+    """
+    ``seed`` is null.
+    """
+    self.assertFilterErrors(
+      {
+        'seed': None,
+      },
+
+      {
+        'seed': [f.Required.CODE_EMPTY],
+      },
+    )
+
+  def test_fail_seed_wrong_type(self):
+    """
+    ``seed`` cannot be converted into a TryteString.
+    """
+    self.assertFilterErrors(
+      {
+        'seed': text_type(self.seed, 'ascii'),
+      },
+
+      {
+        'seed': [f.Type.CODE_WRONG_TYPE],
+      },
+    )
+
+  def test_fail_seed_malformed(self):
+    """
+    ``seed`` has the correct type, but it contains invalid characters.
+    """
+    self.assertFilterErrors(
+      {
+        'seed': b'not valid; seeds can only contain uppercase and "9".',
+      },
+
+      {
+        'seed': [Trytes.CODE_NOT_TRYTES],
+      },
+    )
+
+  def test_fail_start_string(self):
+    """
+    ``start`` is a string.
+    """
+    self.assertFilterErrors(
+      {
+        # Not valid; it must be an int.
+        'start': '0',
+
+        'seed': Seed(self.seed),
+      },
+
+      {
+        'start': [f.Type.CODE_WRONG_TYPE],
+      },
+    )
+
+  def test_fail_start_float(self):
+    """
+    ``start`` is a float.
+    """
+    self.assertFilterErrors(
+      {
+        # Even with an empty fpart, floats are not valid.
+        # It's gotta be an int.
+        'start': 8.0,
+
+        'seed': Seed(self.seed),
+      },
+
+      {
+        'start': [f.Type.CODE_WRONG_TYPE],
+      },
+    )
+
+  def test_fail_start_too_small(self):
+    """
+    ``start`` is less than 0.
+    """
+    self.assertFilterErrors(
+      {
+        'start': -1,
+
+        'seed': Seed(self.seed),
+      },
+
+      {
+        'start': [f.Min.CODE_TOO_SMALL],
+      },
+    )
+
+  def test_fail_stop_string(self):
+    """
+    ``stop`` is a string.
+    """
+    self.assertFilterErrors(
+      {
+        # Not valid; it must be an int.
+        'stop': '0',
+
+        'seed': Seed(self.seed),
+      },
+
+      {
+        'stop': [f.Type.CODE_WRONG_TYPE],
+      },
+    )
+
+  def test_fail_stop_float(self):
+    """
+    ``stop`` is a float.
+    """
+    self.assertFilterErrors(
+      {
+        # Even with an empty fpart, floats are not valid.
+        # It's gotta be an int.
+        'stop': 8.0,
+
+        'seed': Seed(self.seed),
+      },
+
+      {
+        'stop': [f.Type.CODE_WRONG_TYPE],
+      },
+    )
+
+  def test_fail_stop_too_small(self):
+    """
+    ``stop`` is less than 0.
+    """
+    self.assertFilterErrors(
+      {
+        'stop': -1,
+
+        'seed': Seed(self.seed),
+      },
+
+      {
+        'stop': [f.Min.CODE_TOO_SMALL],
+      },
+    )
+
+  def test_fail_stop_occurs_before_start(self):
+    """
+    ``stop`` is less than ``start``.
+    """
+    self.assertFilterErrors(
+      {
+        'start':  1,
+        'stop':   0,
+
+        'seed': Seed(self.seed),
+      },
+
+      {
+        'start': [GetAccountDataRequestFilter.CODE_INTERVAL_INVALID],
+      },
+    )
+
+  def test_fail_interval_too_large(self):
+    """
+    ``stop`` is way more than ``start``.
+    """
+    self.assertFilterErrors(
+      {
+        'start':  0,
+        'stop':   GetAccountDataRequestFilter.MAX_INTERVAL + 1,
+
+        'seed': Seed(self.seed),
+      },
+
+      {
+        'stop':  [GetAccountDataRequestFilter.CODE_INTERVAL_TOO_BIG],
+      },
+    )
+
+  def test_fail_inclusion_states_wrong_type(self):
+    """
+    ``inclusionStates`` is not a boolean.
+    """
+    self.assertFilterErrors(
+      {
+        'inclusionStates': '1',
+
+        'seed': Seed(self.seed),
+      },
+
+      {
+        'inclusionStates': [f.Type.CODE_WRONG_TYPE],
+      },
+    )
 
 
 class GetAccountDataTestCase(TestCase):
+  # noinspection SpellCheckingInspection
   def setUp(self):
     super(GetAccountDataTestCase, self).setUp()
 
-    self.adapter = MockAdapter()
+    self.adapter  = MockAdapter()
+    self.command  = GetAccountDataCommand(self.adapter)
+
+    # Define some tryte sequences we can re-use between tests.
+    self.addy1 =\
+      Address(
+        b'TESTVALUEONE9DONTUSEINPRODUCTION99999YDZ'
+        b'E9TAFAJGJA9CECKDAEPHBICDR9LHFCOFRBQDHC9IG'
+      )
+
+    self.addy2 =\
+      Address(
+        b'TESTVALUETWO9DONTUSEINPRODUCTION99999TES'
+        b'GINEIDLEEHRAOGEBMDLENFDAFCHEIHZ9EBZDD9YHL'
+      )
 
   def test_wireup(self):
     """
@@ -23,3 +345,52 @@ class GetAccountDataTestCase(TestCase):
       Iota(self.adapter).getAccountData,
       GetAccountDataCommand,
     )
+
+  def test_happy_path(self):
+    """
+    Loading account data for an account.
+    """
+    # :todo: Implement test.
+    self.skipTest('Not implemented yet.')
+
+    # To speed up the test, we will mock the address generator.
+    # :py:class:`iota.crypto.addresses.AddressGenerator` already has
+    # its own test case, so this does not impact the stability of the
+    # codebase.
+    # noinspection PyUnusedLocal
+    def create_generator(ag, start, step=1):
+      for addy in [self.addy1, self.addy2][start::step]:
+        yield addy
+
+    # Generate a unique value so we can verify that the correct bundle
+    # data was returned by the command.
+    # noinspection SpellCheckingInspection
+    address =\
+      Address(
+        b'TESTVALUE9DONTUSEINPRODUCTION99999IEUDHI'
+        b'UHDDPEXFVGZGJFBEGFAGZ9GIOGEGED9GMDEEQ9JCB'
+      )
+
+    mock_get_transfers = Mock(return_value={
+      'bundles': [
+        Bundle([
+          Transaction(
+            address = address,
+
+            # The rest of the values are not relevant to this test.
+            bundle_hash   = BundleHash(b''),
+            current_index = 0,
+            hash_         = TransactionHash(b''),
+            last_index    = 0,
+            nonce         = Hash(b''),
+            tag           = Tag(b''),
+            timestamp     = 0,
+            value         = 0,
+
+            branch_transaction_hash     = TransactionHash(b''),
+            trunk_transaction_hash      = TransactionHash(b''),
+            signature_message_fragment  = Fragment(b''),
+          ),
+        ]),
+      ],
+    })

--- a/test/commands/extended/get_account_data_test.py
+++ b/test/commands/extended/get_account_data_test.py
@@ -414,5 +414,18 @@ class GetAccountDataCommandTestCase(TestCase):
     """
     Loading account data for a seed that hasn't been used yet.
     """
-    # :todo: Implement test.
-    self.skipTest('Not implemented yet.')
+    with patch(
+        'iota.commands.extended.get_account_data.iter_used_addresses',
+        Mock(return_value=[]),
+    ):
+      response = self.command(seed=Seed.random())
+
+    self.assertDictEqual(
+      response,
+
+      {
+        'addresses':  [],
+        'balance':    0,
+        'bundles':    [],
+      },
+    )

--- a/test/commands/extended/get_account_data_test.py
+++ b/test/commands/extended/get_account_data_test.py
@@ -1,0 +1,25 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, \
+  unicode_literals
+
+from unittest import TestCase
+
+from iota import Iota
+from iota.adapter import MockAdapter
+from iota.commands.extended.get_account_data import GetAccountDataCommand
+
+
+class GetAccountDataTestCase(TestCase):
+  def setUp(self):
+    super(GetAccountDataTestCase, self).setUp()
+
+    self.adapter = MockAdapter()
+
+  def test_wireup(self):
+    """
+    Verify that the command is wired up correctly.
+    """
+    self.assertIsInstance(
+      Iota(self.adapter).getAccountData,
+      GetAccountDataCommand,
+    )

--- a/test/commands/extended/get_account_data_test.py
+++ b/test/commands/extended/get_account_data_test.py
@@ -6,14 +6,12 @@ from unittest import TestCase
 
 import filters as f
 from filters.test import BaseFilterTestCase
-from iota import Address, Bundle, BundleHash, Fragment, Hash, Iota, Tag, \
-  Transaction, TransactionHash
+from iota import Address, Iota
 from iota.adapter import MockAdapter
 from iota.commands.extended.get_account_data import GetAccountDataCommand, \
   GetAccountDataRequestFilter
 from iota.crypto.types import Seed
 from iota.filters import Trytes
-from mock import Mock
 from six import binary_type, text_type
 
 
@@ -352,45 +350,3 @@ class GetAccountDataTestCase(TestCase):
     """
     # :todo: Implement test.
     self.skipTest('Not implemented yet.')
-
-    # To speed up the test, we will mock the address generator.
-    # :py:class:`iota.crypto.addresses.AddressGenerator` already has
-    # its own test case, so this does not impact the stability of the
-    # codebase.
-    # noinspection PyUnusedLocal
-    def create_generator(ag, start, step=1):
-      for addy in [self.addy1, self.addy2][start::step]:
-        yield addy
-
-    # Generate a unique value so we can verify that the correct bundle
-    # data was returned by the command.
-    # noinspection SpellCheckingInspection
-    address =\
-      Address(
-        b'TESTVALUE9DONTUSEINPRODUCTION99999IEUDHI'
-        b'UHDDPEXFVGZGJFBEGFAGZ9GIOGEGED9GMDEEQ9JCB'
-      )
-
-    mock_get_transfers = Mock(return_value={
-      'bundles': [
-        Bundle([
-          Transaction(
-            address = address,
-
-            # The rest of the values are not relevant to this test.
-            bundle_hash   = BundleHash(b''),
-            current_index = 0,
-            hash_         = TransactionHash(b''),
-            last_index    = 0,
-            nonce         = Hash(b''),
-            tag           = Tag(b''),
-            timestamp     = 0,
-            value         = 0,
-
-            branch_transaction_hash     = TransactionHash(b''),
-            trunk_transaction_hash      = TransactionHash(b''),
-            signature_message_fragment  = Fragment(b''),
-          ),
-        ]),
-      ],
-    })

--- a/test/commands/extended/get_inputs_test.py
+++ b/test/commands/extended/get_inputs_test.py
@@ -580,7 +580,7 @@ class GetInputsCommandTestCase(TestCase):
 
     # When ``stop`` is None, the command uses a generator internally.
     with patch(
-        'iota.crypto.addresses.AddressGenerator.create_generator',
+        'iota.crypto.addresses.AddressGenerator.create_iterator',
         mock_address_generator,
     ):
       response = self.command(
@@ -623,7 +623,7 @@ class GetInputsCommandTestCase(TestCase):
 
     # When ``stop`` is None, the command uses a generator internally.
     with patch(
-        'iota.crypto.addresses.AddressGenerator.create_generator',
+        'iota.crypto.addresses.AddressGenerator.create_iterator',
         mock_address_generator,
     ):
       with self.assertRaises(BadApiResponse):
@@ -677,7 +677,7 @@ class GetInputsCommandTestCase(TestCase):
 
     # When ``stop`` is None, the command uses a generator internally.
     with patch(
-        'iota.crypto.addresses.AddressGenerator.create_generator',
+        'iota.crypto.addresses.AddressGenerator.create_iterator',
         mock_address_generator,
     ):
       response = self.command(
@@ -740,7 +740,7 @@ class GetInputsCommandTestCase(TestCase):
 
     # When ``stop`` is None, the command uses a generator internally.
     with patch(
-        'iota.crypto.addresses.AddressGenerator.create_generator',
+        'iota.crypto.addresses.AddressGenerator.create_iterator',
         mock_address_generator,
     ):
       response = self.command(
@@ -800,7 +800,7 @@ class GetInputsCommandTestCase(TestCase):
 
     # When ``stop`` is None, the command uses a generator internally.
     with patch(
-        'iota.crypto.addresses.AddressGenerator.create_generator',
+        'iota.crypto.addresses.AddressGenerator.create_iterator',
         mock_address_generator,
     ):
       response = self.command(

--- a/test/commands/extended/get_new_addresses_test.py
+++ b/test/commands/extended/get_new_addresses_test.py
@@ -302,7 +302,7 @@ class GetNewAddressesCommandTestCase(TestCase):
         yield addy
 
     with patch(
-        target  = 'iota.crypto.addresses.AddressGenerator.create_generator',
+        target  = 'iota.crypto.addresses.AddressGenerator.create_iterator',
         new     = create_generator,
     ):
       response = self.command(
@@ -346,7 +346,7 @@ class GetNewAddressesCommandTestCase(TestCase):
         yield addy
 
     with patch(
-        target  = 'iota.crypto.addresses.AddressGenerator.create_generator',
+        target  = 'iota.crypto.addresses.AddressGenerator.create_iterator',
         new     = create_generator,
     ):
       response = self.command(

--- a/test/commands/extended/get_transfers_test.py
+++ b/test/commands/extended/get_transfers_test.py
@@ -419,7 +419,7 @@ class GetTransfersCommandTestCase(TestCase):
     })
 
     with patch(
-        'iota.crypto.addresses.AddressGenerator.create_generator',
+        'iota.crypto.addresses.AddressGenerator.create_iterator',
         create_generator,
     ):
       with patch(
@@ -459,7 +459,7 @@ class GetTransfersCommandTestCase(TestCase):
     )
 
     with patch(
-        'iota.crypto.addresses.AddressGenerator.create_generator',
+        'iota.crypto.addresses.AddressGenerator.create_iterator',
         create_generator,
     ):
       response = self.command(seed=Seed.random())
@@ -534,7 +534,7 @@ class GetTransfersCommandTestCase(TestCase):
     })
 
     with patch(
-        'iota.crypto.addresses.AddressGenerator.create_generator',
+        'iota.crypto.addresses.AddressGenerator.create_iterator',
         create_generator,
     ):
       with patch(
@@ -609,7 +609,7 @@ class GetTransfersCommandTestCase(TestCase):
     })
 
     with patch(
-        'iota.crypto.addresses.AddressGenerator.create_generator',
+        'iota.crypto.addresses.AddressGenerator.create_iterator',
         create_generator,
     ):
       with patch(
@@ -717,7 +717,7 @@ class GetTransfersCommandTestCase(TestCase):
     })
 
     with patch(
-        'iota.crypto.addresses.AddressGenerator.create_generator',
+        'iota.crypto.addresses.AddressGenerator.create_iterator',
         create_generator,
     ):
       with patch(

--- a/test/crypto/addresses_test.py
+++ b/test/crypto/addresses_test.py
@@ -2,22 +2,24 @@
 from __future__ import absolute_import, division, print_function, \
   unicode_literals
 
-from typing import Generator, List
+from typing import List, Tuple
 from unittest import TestCase
 
-from mock import patch
+from mock import Mock, patch
 
-from iota import Address, TryteString
-from iota.crypto.addresses import AddressGenerator
+from iota import Address, Hash
+from iota.crypto.addresses import AddressGenerator, MemoryAddressCache
+from iota.crypto.signing import KeyIterator
+from iota.crypto.types import Seed
 
 
-# noinspection SpellCheckingInspection
 class AddressGeneratorTestCase(TestCase):
+  # noinspection SpellCheckingInspection
   def setUp(self):
     super(AddressGeneratorTestCase, self).setUp()
 
     # Addresses that correspond to the digests defined in
-    # :py:meth:`_mock_digest_gen`.
+    # :py:meth:`_mock_get_digest_params`.
     self.addy0 =\
       Address(
         b'VOPYUSDRHYGGOHLAYDWCLLOFWBLK99PYYKENW9IQ'
@@ -51,13 +53,13 @@ class AddressGeneratorTestCase(TestCase):
     ag = AddressGenerator(seed=b'')
 
     # noinspection PyUnresolvedReferences
-    with patch.object(ag, '_create_digest_generator', self._mock_digest_gen):
+    with patch.object(ag, '_get_digest_params', self._mock_get_digest_params):
       addresses = ag.get_addresses(start=0)
 
     self.assertListEqual(addresses, [self.addy0])
 
     # noinspection PyUnresolvedReferences
-    with patch.object(ag, '_create_digest_generator', self._mock_digest_gen):
+    with patch.object(ag, '_get_digest_params', self._mock_get_digest_params):
       # You can provide any positive integer as the ``start`` value.
       addresses = ag.get_addresses(start=2)
 
@@ -72,7 +74,7 @@ class AddressGeneratorTestCase(TestCase):
     ag = AddressGenerator(seed=b'')
 
     # noinspection PyUnresolvedReferences
-    with patch.object(ag, '_create_digest_generator', self._mock_digest_gen):
+    with patch.object(ag, '_get_digest_params', self._mock_get_digest_params):
       addresses = ag.get_addresses(start=1, count=2)
 
     self.assertListEqual(addresses, [self.addy1, self.addy2])
@@ -121,7 +123,7 @@ class AddressGeneratorTestCase(TestCase):
     ag = AddressGenerator(seed=b'')
 
     # noinspection PyUnresolvedReferences
-    with patch.object(ag, '_create_digest_generator', self._mock_digest_gen):
+    with patch.object(ag, '_get_digest_params', self._mock_get_digest_params):
       addresses = ag.get_addresses(start=1, count=2, step=-1)
 
     self.assertListEqual(
@@ -141,7 +143,7 @@ class AddressGeneratorTestCase(TestCase):
     ag = AddressGenerator(seed=b'')
 
     # noinspection PyUnresolvedReferences
-    with patch.object(ag, '_create_digest_generator', self._mock_digest_gen):
+    with patch.object(ag, '_get_digest_params', self._mock_get_digest_params):
       generator = ag.create_generator()
 
       self.assertEqual(next(generator), self.addy0)
@@ -157,15 +159,15 @@ class AddressGeneratorTestCase(TestCase):
     ag = AddressGenerator(seed=b'')
 
     # noinspection PyUnresolvedReferences
-    with patch.object(ag, '_create_digest_generator', self._mock_digest_gen):
+    with patch.object(ag, '_get_digest_params', self._mock_get_digest_params):
       generator = ag.create_generator(start=1, step=2)
 
       self.assertEqual(next(generator), self.addy1)
       self.assertEqual(next(generator), self.addy3)
 
   @staticmethod
-  def _mock_digest_gen(start, step):
-    # type: (int, int) -> Generator[List[int]]
+  def _mock_get_digest_params(key_iterator):
+    # type: (KeyIterator) -> Tuple[List[int], int]
     """
     Mocks the behavior of :py:class:`KeyGenerator`, to speed up unit
     tests.
@@ -173,6 +175,7 @@ class AddressGeneratorTestCase(TestCase):
     Note that :py:class:`KeyGenerator` has its own test case, so we're
     not impacting the stability of the codebase by doing this.
     """
+    # noinspection SpellCheckingInspection
     digests = [
       b'KDWISSPKPF9DZNKMYEVPPYI9CXMFZRAAKCQNMFJI'
       b'JIQLT9IPMEVVNYBTIBTN9CBCJMYTUMSRJAEMUUMIA',
@@ -187,8 +190,142 @@ class AddressGeneratorTestCase(TestCase):
       b'XCWW9M9QGYVUMPXCR9ANPEPVGBI9WOERTFDAGKCVZ',
     ]
 
+    key_index = key_iterator.current
+
+    # Simulate generating the key.
+    key_iterator.current += key_iterator.step
+
     # This should still behave like the real thing, so that we can
     # verify that :py:class`AddressGenerator` is invoking the key
     # generator correctly.
-    for d in digests[start::step]:
-      yield TryteString(d).as_trits()
+    return Hash(digests[key_index]).as_trits(), key_index
+
+
+class MemoryAddressCacheTestCase(TestCase):
+  def setUp(self):
+    super(MemoryAddressCacheTestCase, self).setUp()
+
+    # Define some values we can reuse across tests.
+    # noinspection SpellCheckingInspection
+    self.addy =\
+      Address(
+        trytes =
+          b'TESTVALUE9DONTUSEINPRODUCTION99999J9XDHH'
+          b'LHKET9PHTEUAHFFCDCP9ECIDPALFMFSCTCIHMD9CY',
+
+        key_index = 42,
+      )
+
+  def tearDown(self):
+    super(MemoryAddressCacheTestCase, self).tearDown()
+
+    # Disable the global cache, in case the test installed one.
+    AddressGenerator.cache = None
+
+  def test_global_cache(self):
+    """
+    Installing a cache that affects all :py:class:`AddressGenerator`
+    instances.
+    """
+    # Install the cache globally.
+    AddressGenerator.cache = MemoryAddressCache()
+
+    mock_generate_address = Mock(return_value=self.addy)
+
+    with patch(
+        'iota.crypto.addresses.AddressGenerator._generate_address',
+        mock_generate_address,
+    ):
+      generator1 = AddressGenerator(Seed.random())
+
+      addy1 = generator1.get_addresses(42)
+      mock_generate_address.assert_called_once()
+
+      # The second time we try to generate the same address, it is
+      # fetched from the cache.
+      addy2 = generator1.get_addresses(42)
+      mock_generate_address.assert_called_once()
+      self.assertEqual(addy2, addy1)
+
+      # Create a new AddressGenerator and verify it uses the same
+      # cache.
+      generator2 = AddressGenerator(generator1.seed)
+
+      # Cache is global, so the cached address is returned again.
+      addy3 = generator2.get_addresses(42)
+      mock_generate_address.assert_called_once()
+      self.assertEqual(addy3, addy1)
+
+  def test_local_cache(self):
+    """
+    Installing a cache only for a single instance of
+    :py:class:`AddressGenerator`.
+    """
+    mock_generate_address = Mock(return_value=self.addy)
+
+    with patch(
+        'iota.crypto.addresses.AddressGenerator._generate_address',
+        mock_generate_address,
+    ):
+      generator1 = AddressGenerator(Seed.random())
+
+      # Install the cache locally.
+      generator1.cache = MemoryAddressCache()
+
+      addy1 = generator1.get_addresses(42)
+      mock_generate_address.assert_called_once()
+
+      # The second time we try to generate the same address, it is
+      # fetched from the cache.
+      addy2 = generator1.get_addresses(42)
+      mock_generate_address.assert_called_once()
+      self.assertEqual(addy2, addy1)
+
+      # Create a new instance to verify it has its own cache.
+      generator2 = AddressGenerator(generator1.seed)
+
+      # The generator has its own cache instance, so even though the
+      # resulting address is the same, it is not fetched from cache.
+      addy3 = generator2.get_addresses(42)
+      self.assertEqual(mock_generate_address.call_count, 2)
+      self.assertEqual(addy3, addy1)
+
+  def test_cache_miss_key_index(self):
+    """
+    Cached addresses are keyed by key index.
+    """
+    AddressGenerator.cache = MemoryAddressCache()
+
+    mock_generate_address = Mock(return_value=self.addy)
+
+    with patch(
+        'iota.crypto.addresses.AddressGenerator._generate_address',
+        mock_generate_address,
+    ):
+      generator = AddressGenerator(Seed.random())
+
+      generator.get_addresses(42)
+      mock_generate_address.assert_called_once()
+
+      generator.get_addresses(43)
+      self.assertEqual(mock_generate_address.call_count, 2)
+
+  def test_cache_miss_seed(self):
+    """
+    Cached addresses are keyed by seed.
+    """
+    AddressGenerator.cache = MemoryAddressCache()
+
+    mock_generate_address = Mock(return_value=self.addy)
+
+    with patch(
+        'iota.crypto.addresses.AddressGenerator._generate_address',
+        mock_generate_address,
+    ):
+      generator1 = AddressGenerator(Seed.random())
+      generator1.get_addresses(42)
+      mock_generate_address.assert_called_once()
+
+      generator2 = AddressGenerator(Seed.random())
+      generator2.get_addresses(42)
+      self.assertEqual(mock_generate_address.call_count, 2)

--- a/test/crypto/addresses_test.py
+++ b/test/crypto/addresses_test.py
@@ -144,7 +144,7 @@ class AddressGeneratorTestCase(TestCase):
 
     # noinspection PyUnresolvedReferences
     with patch.object(ag, '_get_digest_params', self._mock_get_digest_params):
-      generator = ag.create_generator()
+      generator = ag.create_iterator()
 
       self.assertEqual(next(generator), self.addy0)
       self.assertEqual(next(generator), self.addy1)
@@ -160,7 +160,7 @@ class AddressGeneratorTestCase(TestCase):
 
     # noinspection PyUnresolvedReferences
     with patch.object(ag, '_get_digest_params', self._mock_get_digest_params):
-      generator = ag.create_generator(start=1, step=2)
+      generator = ag.create_iterator(start=1, step=2)
 
       self.assertEqual(next(generator), self.addy1)
       self.assertEqual(next(generator), self.addy3)

--- a/test/crypto/signing_test.py
+++ b/test/crypto/signing_test.py
@@ -546,10 +546,10 @@ class KeyGeneratorTestCase(TestCase):
       seed = b'TESTSEED9DONTUSEINPRODUCTION99999IPKZWMLYYOLWBJGINLSO9EEYQMCUJ',
     )
 
-    generator = kg.create_generator()
+    iterator = kg.create_iterator()
 
     self.assertEqual(
-      next(generator),
+      next(iterator),
 
       PrivateKey(
         b'LZDQHHPRICEESIHX9VVYCHLYSJDMXPLFOMMVOMUZKHSXLQYSQNDFHWLNKTCAJYPWUM'
@@ -590,7 +590,7 @@ class KeyGeneratorTestCase(TestCase):
     )
 
     self.assertEqual(
-      next(generator),
+      next(iterator),
 
       PrivateKey(
         b'BTQKIPUTHFDMCKGVLBCFGEFLJHCHOANY9GBIRSODCOWTJGUWGFMDXWEB9HDNP9M9ZU'
@@ -638,10 +638,10 @@ class KeyGeneratorTestCase(TestCase):
       seed = b'TESTSEED9DONTUSEINPRODUCTION99999FFRFYAMRNWLGSGZNYUJNEBNWJQNYF',
     )
 
-    generator = kg.create_generator(start=3, step=2)
+    iterator = kg.create_iterator(start=3, step=2)
 
     self.assertEqual(
-      next(generator),
+      next(iterator),
 
       PrivateKey(
         b'CBKFYOTDYHFWSIOUYAUAHQWOOQDNNQBTSSJPHREUWFBXZFYFHPHZJN9ILAMZYOXLBQ'
@@ -682,7 +682,7 @@ class KeyGeneratorTestCase(TestCase):
     )
 
     self.assertEqual(
-      next(generator),
+      next(iterator),
 
       PrivateKey(
         b'OTOFWEAUQFRSWBTJPPAACBIPCTMYAESBAGVMPVMH9IQAEEKEXVUCSOWORDIQBRZZLD'
@@ -733,10 +733,10 @@ class KeyGeneratorTestCase(TestCase):
       seed = b'TESTSEED9DONTUSEINPRODUCTION99999FFRFYAMRNWLGSGZNYUJNEBNWJQNYF',
     )
 
-    generator = kg.create_generator(start=3, iterations=2)
+    iterator = kg.create_iterator(start=3, iterations=2)
 
     self.assertEqual(
-      next(generator),
+      next(iterator),
 
       PrivateKey(
         b'CBKFYOTDYHFWSIOUYAUAHQWOOQDNNQBTSSJPHREUWFBXZFYFHPHZJN9ILAMZYOXLBQ'


### PR DESCRIPTION
# PyOTA v1.1.1
**IMPORTANT:** This version contains a few changes that are not backwards-compatible with v1.1.0.

## Backwards-Incompatible Changes
- Renamed `AddressGenerator.create_generator` to `create_iterator`.
- Renamed `KeyGenerator.create_generator` to `create_iterator`.
- Removed `normalize` from `iota.crypto.signing.*`.

## Adapters
- [#23] `SandboxAdapter` now gives up if a job hasn't completed after 8 polling checks.
- `BadApiResponse` messages now include the HTTP status code from the response.

## Address Caching (New Feature!)
- Implemented `MemoryAddressCache`, which caches generated addresses in process memory.
  - To activate, execute `AddressGenerator.cache = MemoryAddressCache()`.

## API Commands
- [#27] Implemented `getAccountData` command.
- Fixed an exception when invoking `findTransactions` with no hashes.
- Reorganized commands to make IDE navigation easier (thanks @alon-e for the idea!).
- Added `iota.commands.extended.utils` module, containing utility methods used by extended API commands.

## Crypto
- Implemented `KeyIterator`.  Behaves identically to `KeyGenerator.create_generator` from v1.1.0, but provides additional methods to access iteration metadata.

## Example Scripts
- Integrated `MemoryAddressCache` into REPL script.
- [#29] Fixed a configuration issue preventing the `hello_world` and `address_generator` example scripts from running (thanks @alon-e for reporting the issue!).

## Misc.
- Added IPython pretty-printer support to many PyOTA classes.
  - Unfortunately, the built-in `pprint` library does not support this customization.
- Cleaned up distutils metadata.
- Cleaned up Travis configuration.
- Minor documentation and imports cleanup.
