### PR TITLE
1.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
   name        = 'PyOTA',
   description = 'IOTA API library for Python',
   url         = 'https://github.com/iotaledger/iota.lib.py',
-  version     = '1.1.1',
+  version     = '1.1.2',
 
   packages              = find_packages('src'),
   include_package_data  = True,

--- a/src/iota/api.py
+++ b/src/iota/api.py
@@ -822,8 +822,8 @@ class Iota(StrictIota):
       minWeightMagnitude  = min_weight_magnitude,
     )
 
-  def send_trytes(self, trytes, depth, min_weight_magnitude=18):
-    # type: (Iterable[TransactionTrytes], int, int) -> dict
+  def send_trytes(self, trytes, depth, min_weight_magnitude=None):
+    # type: (Iterable[TransactionTrytes], int, Optional[int]) -> dict
     """
     Attaches transaction trytes to the Tangle, then broadcasts and
     stores them.
@@ -851,6 +851,9 @@ class Iota(StrictIota):
     References:
       - https://github.com/iotaledger/wiki/blob/master/api-proposal.md#sendtrytes
     """
+    if min_weight_magnitude is None:
+      min_weight_magnitude = self.default_min_weight_magnitude
+
     return extended.SendTrytesCommand(self.adapter)(
       trytes              = trytes,
       depth               = depth,

--- a/src/iota/crypto/addresses.py
+++ b/src/iota/crypto/addresses.py
@@ -59,11 +59,8 @@ class BaseAddressCache(with_metaclass(ABCMeta)):
     Note: Acquire lock before checking the cache, and do not release it
     until after the cache hit/miss is resolved.
     """
-    self._lock.acquire()
-    try:
+    with self._lock:
       yield
-    finally:
-      self._lock.release()
 
   @abstract_method
   def set(self, seed, index, address):

--- a/src/iota/crypto/addresses.py
+++ b/src/iota/crypto/addresses.py
@@ -4,7 +4,8 @@ from __future__ import absolute_import, division, print_function, \
 
 import hashlib
 from abc import ABCMeta, abstractmethod as abstract_method
-from typing import Dict, Generator, Iterable, List, MutableSequence, Optional
+from typing import Dict, Generator, Iterable, List, MutableSequence, \
+  Optional, Tuple
 
 from iota import Address, TRITS_PER_TRYTE, TrytesCompatible
 from iota.crypto import Curl
@@ -45,6 +46,17 @@ class BaseAddressCache(with_metaclass(ABCMeta)):
       'Not implemented in {cls}.'.format(cls=type(self).__name__),
     )
 
+  @staticmethod
+  def _gen_cache_key(seed, index):
+    # type: (Seed, int) -> binary_type
+    """
+    Generates an obfuscated cache key so that we're not storing seeds
+    in cleartext.
+    """
+    h = hashlib.new('sha256')
+    h.update(binary_type(seed) + b':' + binary_type(index))
+    return h.digest()
+
 
 class MemoryAddressCache(BaseAddressCache):
   """
@@ -62,17 +74,6 @@ class MemoryAddressCache(BaseAddressCache):
   def set(self, seed, index, address):
     # type: (Seed, int, Address) -> None
     self.cache[self._gen_cache_key(seed, index)] = address
-
-  @staticmethod
-  def _gen_cache_key(seed, index):
-    # type: (Seed, int) -> binary_type
-    """
-    Generates an obfuscated cache key so that we're not storing seeds
-    in cleartext.
-    """
-    h = hashlib.new('sha256')
-    h.update(binary_type(seed) + b':' + binary_type(index))
-    return h.digest()
 
 
 class AddressGenerator(Iterable[Address]):

--- a/src/iota/crypto/addresses.py
+++ b/src/iota/crypto/addresses.py
@@ -256,7 +256,7 @@ class AddressGenerator(Iterable[Address]):
       yield address
 
   @staticmethod
-  def address_from_digest(digest_trits, key_index):
+  def address_from_digest_trits(digest_trits, key_index):
     # type: (List[int], int) -> Address
     """
     Generates an address from a private key digest.
@@ -279,13 +279,13 @@ class AddressGenerator(Iterable[Address]):
 
     Used in the event of a cache miss.
     """
-    return self.address_from_digest(*self._get_digest_params(key_iterator))
+    return self.address_from_digest_trits(*self._get_digest_params(key_iterator))
 
   @staticmethod
   def _get_digest_params(key_iterator):
     # type: (KeyIterator) -> Tuple[List[int], int]
     """
-    Extracts parameters for :py:meth:`address_from_digest`.
+    Extracts parameters for :py:meth:`address_from_digest_trits`.
 
     Split into a separate method so that it can be mocked during unit
     tests.

--- a/test/crypto/addresses_test.py
+++ b/test/crypto/addresses_test.py
@@ -46,6 +46,26 @@ class AddressGeneratorTestCase(TestCase):
         b'CFANWBQFGMFKITZBJDSYLGXYUIQVCMXFWSWFRNHRV'
       )
 
+  # noinspection SpellCheckingInspection
+  def test_address_from_digest(self):
+    """
+    Generating an address from a private key digest.
+    """
+    digest =\
+      Hash(
+        b'ABQXVJNER9MPMXMBPNMFBMDGTXRWSYHNZKGAGUOI'
+        b'JKOJGZVGHCUXXGFZEMMGDSGWDCKJXO9ILLFAKGGZE'
+      )
+
+    self.assertEqual(
+      AddressGenerator.address_from_digest_trits(digest.as_trits(), 0),
+
+      Address(
+        b'QLOEDSBXXOLLUJYLEGKEPYDRIJJTPIMEPKMFHUVJ'
+        b'MPMLYYCLPQPANEVDSERQWPVNHCAXYRLAYMBHJLWWR'
+      ),
+    )
+
   def test_get_addresses_single(self):
     """
     Generating a single address.


### PR DESCRIPTION
# PyOTA v1.1.2
## Address Caching
- [#35] Address caches are now thread-safe.

## Address Generator
- Renamed `address_from_digest` to `address_from_digest_trits`.
- Improved test coverage.