### PR TITLE
PyOTA v2.0.0b2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ script: nosetests
 deploy:
   on:
     branch: master
+    python: '3.6'
   provider: pypi
   distribution: 'bdist_wheel sdist'
   skip_upload_docs: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ install: pip install .
 script: nosetests
 deploy:
   on:
-    branch: master
     python: '3.6'
+    tags: true
   provider: pypi
   distribution: 'bdist_wheel sdist'
   skip_upload_docs: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ deploy:
   on:
     branch: master
   provider: pypi
-  distribution: bdist_wheel sdist
+  distribution: 'bdist_wheel sdist'
   skip_upload_docs: true
   user: phx
   password:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include LICENSE
 recursive-include examples *.py
-recursive-include test *.py
+recursive-include test *.py *.csv

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
   name        = 'PyOTA',
   description = 'IOTA API library for Python',
   url         = 'https://github.com/iotaledger/iota.lib.py',
-  version     = '2.0.0b1',
+  version     = '2.0.0b2',
 
   long_description = long_description,
 


### PR DESCRIPTION
**⚠️ This is pre-release software! Do not use in production contexts! ⚠️**

## Release Notes (since v2.0.0b1)
**If you are upgrading from PyOTA v1.1.3, please also review the release notes for [v1.2.0-beta1](https://github.com/iotaledger/iota.lib.py/releases/tag/1.2.0b1) and [v2.0.0-beta1](https://github.com/iotaledger/iota.lib.py/releases/tag/2.0.0b1).**

# Bugfixes
* Added missing support files to source distributions.
* Fix an issue preventing Travis CI from publishing binary distros to PyPI.
* Travis CI now only deploys tagged releases to PyPI.
    * After v2.0.0, `master` will only contain the latest production release of PyOTA.