### PR TITLE
Renamed 'trytes' codec to 'trytes_ascii'.

### DIFF
--- a/iota/__init__.py
+++ b/iota/__init__.py
@@ -28,7 +28,7 @@ STANDARD_UNITS = {
 }
 
 
-# Activate TrytesCodec.
+# Activate codecs.
 from .codecs import *
 
 # Make some imports accessible from the top level of the package.

--- a/iota/transaction/base.py
+++ b/iota/transaction/base.py
@@ -457,7 +457,7 @@ class Bundle(JsonSerializable, Sequence[Transaction]):
     return self[0]
 
   def get_messages(self, errors='drop'):
-    # type: () -> List[Text]
+    # type: (Text) -> List[Text]
     """
     Attempts to decipher encoded messages from the transactions in the
     bundle.

--- a/test/codecs_test.py
+++ b/test/codecs_test.py
@@ -2,53 +2,67 @@
 from __future__ import absolute_import, division, print_function, \
   unicode_literals
 
-from codecs import encode, decode
+from codecs import decode, encode
 from unittest import TestCase
+from warnings import catch_warnings, simplefilter as simple_filter
+
+from six import text_type
+
+from iota.codecs import AsciiTrytesCodec, TrytesDecodeError
 
 
 # noinspection SpellCheckingInspection
-from iota.codecs import TrytesDecodeError
-
-
-# noinspection SpellCheckingInspection
-class TrytesCodecTestCase(TestCase):
+class AsciiTrytesCodecTestCase(TestCase):
   def test_encode_byte_string(self):
-    """Encoding a byte string into trytes."""
+    """
+    Encoding a byte string into trytes.
+    """
     self.assertEqual(
-      encode(b'Hello, IOTA!', 'trytes'),
+      encode(b'Hello, IOTA!', AsciiTrytesCodec.name),
       b'RBTC9D9DCDQAEASBYBCCKBFA',
     )
 
   def test_encode_bytearray(self):
-    """Encoding a bytearray into trytes."""
+    """
+    Encoding a bytearray into trytes.
+    """
     self.assertEqual(
-      encode(bytearray(b'Hello, IOTA!'), 'trytes'),
+      encode(bytearray(b'Hello, IOTA!'), AsciiTrytesCodec.name),
       b'RBTC9D9DCDQAEASBYBCCKBFA',
     )
 
   def test_encode_error_wrong_type(self):
-    """Attempting to encode a value with an incompatible type."""
+    """
+    Attempting to encode a value with an incompatible type.
+    """
     with self.assertRaises(TypeError):
       # List value not accepted; it can contain things other than bytes
-      #   (ordinals in range(255), that is).
-      encode([72, 101, 108, 108, 111, 44, 32, 73, 79, 84, 65, 33], 'trytes')
+      # (ordinals in range(255), that is).
+      encode(
+        [72, 101, 108, 108, 111, 44, 32, 73, 79, 84, 65, 33],
+        AsciiTrytesCodec.name,
+      )
 
     with self.assertRaises(TypeError):
       # Unicode strings not accepted; it is ambiguous whether and how
       #   to encode to bytes.
-      encode('Hello, IOTA!', 'trytes')
+      encode('Hello, IOTA!', AsciiTrytesCodec.name)
 
   def test_decode_byte_string(self):
-    """Decoding trytes to a byte string."""
+    """
+    Decoding trytes to a byte string.
+    """
     self.assertEqual(
-      decode(b'RBTC9D9DCDQAEASBYBCCKBFA', 'trytes'),
+      decode(b'RBTC9D9DCDQAEASBYBCCKBFA', AsciiTrytesCodec.name),
       b'Hello, IOTA!',
     )
 
   def test_decode_bytearray(self):
-    """Decoding a bytearray of trytes into a byte string."""
+    """
+    Decoding a bytearray of trytes into a byte string.
+    """
     self.assertEqual(
-      decode(bytearray(b'RBTC9D9DCDQAEASBYBCCKBFA'), 'trytes'),
+      decode(bytearray(b'RBTC9D9DCDQAEASBYBCCKBFA'), AsciiTrytesCodec.name),
       b'Hello, IOTA!',
     )
 
@@ -57,14 +71,14 @@ class TrytesCodecTestCase(TestCase):
     Attempting to decode an odd number of trytes with errors='strict'.
     """
     with self.assertRaises(TrytesDecodeError):
-      decode(b'RBTC9D9DCDQAEASBYBCCKBFA9', 'trytes', 'strict')
+      decode(b'RBTC9D9DCDQAEASBYBCCKBFA9', AsciiTrytesCodec.name, 'strict')
 
   def test_decode_wrong_length_errors_ignore(self):
     """
     Attempting to decode an odd number of trytes with errors='ignore'.
     """
     self.assertEqual(
-      decode(b'RBTC9D9DCDQAEASBYBCCKBFA9', 'trytes', 'ignore'),
+      decode(b'RBTC9D9DCDQAEASBYBCCKBFA9', AsciiTrytesCodec.name, 'ignore'),
       b'Hello, IOTA!',
     )
 
@@ -73,34 +87,51 @@ class TrytesCodecTestCase(TestCase):
     Attempting to decode an odd number of trytes with errors='replace'.
     """
     self.assertEqual(
-      decode(b'RBTC9D9DCDQAEASBYBCCKBFA9', 'trytes', 'replace'),
+      decode(b'RBTC9D9DCDQAEASBYBCCKBFA9', AsciiTrytesCodec.name, 'replace'),
       b'Hello, IOTA!?',
     )
 
   def test_decode_invalid_pair_errors_strict(self):
     """
     Attempting to decode an un-decodable pair of trytes with
-      errors='strict'.
+    errors='strict'.
     """
     with self.assertRaises(TrytesDecodeError):
-      decode(b'ZJVYUGTDRPDYFGFXMK', 'trytes', 'strict')
+      decode(b'ZJVYUGTDRPDYFGFXMK', AsciiTrytesCodec.name, 'strict')
 
   def test_decode_invalid_pair_errors_ignore(self):
     """
     Attempting to decode an un-decodable pair of trytes with
-      errors='ignore'.
+    errors='ignore'.
     """
     self.assertEqual(
-      decode(b'ZJVYUGTDRPDYFGFXMK', 'trytes', 'ignore'),
+      decode(b'ZJVYUGTDRPDYFGFXMK', AsciiTrytesCodec.name, 'ignore'),
       b'\xd2\x80\xc3',
     )
 
   def test_decode_invalid_pair_errors_replace(self):
     """
     Attempting to decode an un-decodable pair of trytes with
-      errors='replace'.
+    errors='replace'.
     """
     self.assertEqual(
-      decode(b'ZJVYUGTDRPDYFGFXMK', 'trytes', 'replace'),
+      decode(b'ZJVYUGTDRPDYFGFXMK', AsciiTrytesCodec.name, 'replace'),
       b'??\xd2\x80??\xc3??',
     )
+
+  def test_compat_name(self):
+    """
+    A warning is raised when using the codec's old name.
+    """
+    with catch_warnings(record=True) as warnings:
+      simple_filter('always', category=DeprecationWarning)
+
+      self.assertEqual(
+        # Provide the old codec name to :py:func:`encode`.
+        encode(b'Hello, IOTA!', AsciiTrytesCodec.compat_name),
+        b'RBTC9D9DCDQAEASBYBCCKBFA',
+      )
+
+    self.assertEqual(len(warnings), 1)
+    self.assertEqual(warnings[0].category, DeprecationWarning)
+    self.assertIn('codec will be removed', text_type(warnings[0].message))

--- a/test/crypto/types_test.py
+++ b/test/crypto/types_test.py
@@ -5,6 +5,8 @@ from __future__ import absolute_import, division, print_function, \
 import warnings
 from unittest import TestCase
 
+from six import text_type
+
 from iota import Hash, TryteString
 from iota.crypto import SeedWarning
 from iota.crypto.types import Digest, PrivateKey, Seed
@@ -48,7 +50,10 @@ class SeedTestCase(TestCase):
       # check attributes of warning
       self.assertEqual(len(catched_warnings), 1)
       self.assertIs(catched_warnings[-1].category, SeedWarning)
-      self.assertIn("inappropriate length", str(catched_warnings[-1].message))
+      self.assertIn(
+        "inappropriate length",
+        text_type(catched_warnings[-1].message),
+      )
 
       self.assertEqual(len(seed), Hash.LEN + 1)
 

--- a/test/types_test.py
+++ b/test/types_test.py
@@ -7,7 +7,7 @@ from unittest import TestCase
 from six import binary_type, text_type
 
 from iota import Address, AddressChecksum, Hash, Tag, TryteString, \
-  TrytesCodec, TrytesDecodeError, trits_from_int
+  AsciiTrytesCodec, TrytesDecodeError, trits_from_int
 
 
 class TritsFromIntTestCase(TestCase):
@@ -592,7 +592,7 @@ class TryteStringTestCase(TestCase):
     self.assertDictEqual(
       {
         chr(c): TryteString(chr(c).encode('ascii')).as_trytes()
-          for c in TrytesCodec.alphabet.values()
+          for c in AsciiTrytesCodec.alphabet.values()
       },
 
       {
@@ -666,7 +666,7 @@ class TryteStringTestCase(TestCase):
     self.assertDictEqual(
       {
         chr(c): TryteString(chr(c).encode('ascii')).as_trits()
-          for c in TrytesCodec.alphabet.values()
+          for c in AsciiTrytesCodec.alphabet.values()
       },
 
       {


### PR DESCRIPTION
The previous name will still work, but it is deprecated and will be removed in PyOTA v2.

This change will make it easier to transition to the new trits <-> bytes codec for #62.