### PR TITLE
setup: Check for setuptools version and inform user

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools import find_packages, setup
 from distutils.version import LooseVersion
 if LooseVersion(setuptools.__version__) < LooseVersion('20.5'):
     import sys
-    sys.exit('First, you have to upgrade your setuptools.')
+    sys.exit('Installation failed: Upgrade setuptools to version 20.5 or later')
 
 ##
 # Load long description for PyPi.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,13 @@ from __future__ import absolute_import, division, print_function
 
 from codecs import StreamReader, open
 
+import setuptools
 from setuptools import find_packages, setup
+
+from distutils.version import LooseVersion
+if LooseVersion(setuptools.__version__) < LooseVersion('20.5'):
+    import sys
+    sys.exit('First, you have to upgrade your setuptools.')
 
 ##
 # Load long description for PyPi.


### PR DESCRIPTION
fixes #83

debian jessie's (and maybe others?) apt-get ships a rather deprecated version of setuptools (5.5.1). Setup of pyota failed with a rather unclear exiting message:

    X@Y:/usr/local/src/pyota$ sudo python setup.py install 
    error in PyOTA setup command: 'install_requires' must be a string or list of strings containing valid 
    project/version requirement specifiers

Same with installing via pip. I went through the version log of setuptools and found 'install_requires' was touched in versions 5.5, 20.5. and later. I tested with version 20.7. with which setup was flawless. So, I assume version 20.5. is the minimum requirement. 