### PR TITLE
Release/2.0.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
   name        = 'PyOTA',
   description = 'IOTA API library for Python',
   url         = 'https://github.com/iotaledger/iota.lib.py',
-  version     = '2.0.1',
+  version     = '2.0.2',
 
   long_description = long_description,
 


### PR DESCRIPTION
# PyOTA v2.0.2
* [#96] `find_transactions` now omits null search terms from the request payload.