### PR TITLE
Simplify ProposedMultisigBundle

### DIFF
--- a/iota/multisig/transaction.py
+++ b/iota/multisig/transaction.py
@@ -32,65 +32,49 @@ class ProposedMultisigBundle(ProposedBundle):
 
       Note: at this time, only a single multisig input is supported.
     """
+
     if self.hash:
       raise RuntimeError('Bundle is already finalized.')
 
-    count = 0
-    for addy in inputs:
-      if count > 0:
-        raise ValueError(
-          '{cls} only supports 1 input.'.format(cls=type(self).__name__),
+    if not inputs or len(inputs) != 1:
+      raise ValueError(
+        '{cls} requires input MultisigAddresses and currently only supports 1'
+        ' input.'
+        .format(cls=type(self).__name__),
+      )
+
+    # Validate all addresses
+    for address in inputs:
+      exc = None
+      security_level = address.security_level
+      exception_context = {'actual_input': address}
+
+      if not isinstance(address, MultisigAddress):
+        exc = TypeError(
+          'Incorrect input type for {cls} '
+          '(expected {expected}, actual {actual}).'.format(
+            actual    = type(address).__name__,
+            cls       = type(self).__name__,
+            expected  = MultisigAddress.__name__,
+          ),
+        )
+      elif security_level < 1:
+        exception_context['security_level'] = security_level
+        exc = ValueError(
+          'Unable to determine security level for {type} '
+          '(is ``digests`` populated correctly?).'.format(
+            type = type(address).__name__,
+          ),
+        )
+      elif not address.balance:
+        exc = ValueError(
+          'Cannot add input with empty/unknown balance to {type} '
+          '(use ``Iota.get_balances`` to get balance first).'.format(
+            type = type(self).__name__,
+          ),
         )
 
-      if not isinstance(addy, MultisigAddress):
-        raise with_context(
-          exc =
-            TypeError(
-              'Incorrect input type for {cls} '
-              '(expected {expected}, actual {actual}).'.format(
-                actual    = type(addy).__name__,
-                cls       = type(self).__name__,
-                expected  = MultisigAddress.__name__,
-              ),
-            ),
+      if exc is not None:
+        raise with_context(exc=exc, context=exception_context)
 
-          context = {
-            'actual_input': addy,
-          },
-        )
-
-      security_level = addy.security_level
-      if security_level < 1:
-        raise with_context(
-          exc =
-            ValueError(
-              'Unable to determine security level for {type} '
-              '(is ``digests`` populated correctly?).'.format(
-                type = type(addy).__name__,
-              ),
-            ),
-
-          context = {
-            'actual_input':   addy,
-            'security_level': security_level,
-          },
-        )
-
-      if not addy.balance:
-        raise with_context(
-          exc =
-            ValueError(
-              'Cannot add input with empty/unknown balance to {type} '
-              '(use ``Iota.get_balances`` to get balance first).'.format(
-                type = type(self).__name__,
-              ),
-            ),
-
-          context = {
-            'actual_input': addy,
-          },
-        )
-
-      self._create_input_transactions(addy)
-
-      count += 1
+    map(self._create_input_transactions, inputs)


### PR DESCRIPTION
**Context**
The current ProposedMultisigBundle validates various conditions and if
applicable, raises exceptions. At a brief glance, the code did not look
as human friendly as it can be.

The proposed changes seek to simply the module as well as breakup the
code into logical pieces which makes it easy to reason with. As a
consequence, the code is also much more compact.

**Due Diligence**
It seems the original tests might be failing. There was a hardcoded rejection of inputs length greater than 1 but I see some tests passing ~5 params. I've validated that I did not fail any other tests, but I'd like some clarification related to this.

\---

**Questions for Gatekeepers**
1. What style guide/PEP standard are you using as it does not seem to be PEP8
2. To that end, what docstring format are we using? It seems to be inconsistent at the moment. Are we open to considering documenting as per the folks at [numpy](sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html)? That docstring is autodetected by Sphinx which we can use for documentation.

\---

**Note**
\- First contribution to the project ⚡️⚡️⚡️ . I hope its not a major change. I tried to join Slack to pitch the change first. However, the invite has expired.
\- This branch was originally based off of master hence the `master-` prefix. However, I've made the change locally to have the branch based off of develop and cherry-picked the changed. Branch name had to be kept the same to avoid having this PR disappear.