### PR TITLE
add promote_transaction_api

### DIFF
--- a/iota/api.py
+++ b/iota/api.py
@@ -775,6 +775,33 @@ class Iota(StrictIota):
       changeAddress = change_address,
     )
 
+  def promote_transaction(
+      self,
+      transaction,
+      depth,
+      min_weight_magnitude = None,
+  ):
+    # type: (TransactionHash, int, Optional[int]) -> dict
+    """
+    Promotes a transaction by adding spam on top of it.
+
+    :return:
+      Dict containing the following values::
+
+         {
+           'bundle': Bundle,
+             The newly-published bundle.
+         }
+    """
+    if min_weight_magnitude is None:
+        min_weight_magnitude = self.default_min_weight_magnitude
+
+    return extended.PromoteTransactionCommand(self.adapter)(
+      transaction         = transaction,
+      depth               = depth,
+      minWeightMagnitude  = min_weight_magnitude,
+    )
+
   def replay_bundle(
       self,
       transaction,

--- a/iota/commands/core/get_transactions_to_approve.py
+++ b/iota/commands/core/get_transactions_to_approve.py
@@ -32,7 +32,25 @@ class GetTransactionsToApproveRequestFilter(RequestFilter):
   def __init__(self):
     super(GetTransactionsToApproveRequestFilter, self).__init__({
       'depth': f.Required | f.Type(int) | f.Min(1),
+
+      'reference': Trytes(result_type=TransactionHash),
+    },
+
+    allow_missing_keys = {
+      'reference',
     })
+
+  def _apply(self, value):
+    value = super(GetTransactionsToApproveRequestFilter, self)._apply(value) # type: dict
+
+    if self._has_errors:
+      return value
+
+    # Remove reference if null.
+    if value['reference'] is None:
+      del value['reference']
+
+    return value
 
 
 class GetTransactionsToApproveResponseFilter(ResponseFilter):

--- a/iota/commands/extended/__init__.py
+++ b/iota/commands/extended/__init__.py
@@ -19,6 +19,7 @@ from .get_latest_inclusion import *
 from .get_new_addresses import *
 from .get_transfers import *
 from .prepare_transfer import *
+from .promote_transaction import *
 from .replay_bundle import *
 from .send_transfer import *
 from .send_trytes import *

--- a/iota/commands/extended/promote_transaction.py
+++ b/iota/commands/extended/promote_transaction.py
@@ -1,0 +1,68 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, \
+  unicode_literals
+
+import filters as f
+from iota import (
+  Bundle, TransactionHash, Address, ProposedTransaction, BadApiResponse,
+)
+from iota.commands import FilterCommand, RequestFilter
+from iota.commands.core.check_consistency import CheckConsistencyCommand
+from iota.commands.extended.send_transfer import SendTransferCommand
+from iota.filters import Trytes
+
+__all__ = [
+  'PromoteTransactionCommand',
+]
+
+
+class PromoteTransactionCommand(FilterCommand):
+  """
+  Executes ``promoteTransaction`` extended API command.
+
+  See :py:meth:`iota.api.Iota.promote_transaction` for more information.
+  """
+  command = 'promoteTransaction'
+
+  def get_request_filter(self):
+    return PromoteTransactionRequestFilter()
+
+  def get_response_filter(self):
+    pass
+
+  def _execute(self, request):
+    depth                 = request['depth'] # type: int
+    min_weight_magnitude  = request['minWeightMagnitude'] # type: int
+    transaction           = request['transaction'] # type: TransactionHash
+
+    cc_response = CheckConsistencyCommand(self.adapter)(tails=[transaction])
+    if cc_response['state'] is False:
+      raise BadApiResponse(
+        'Transaction {transaction} is not promotable. '
+        'You should reattach first.'.format(transaction=transaction)
+      )
+
+    spam_transfer = ProposedTransaction(
+      address=Address(b''),
+      value=0,
+    )
+
+    return SendTransferCommand(self.adapter)(
+      seed=spam_transfer.address,
+      depth=depth,
+      transfers=[spam_transfer],
+      minWeightMagnitude=min_weight_magnitude,
+      reference=transaction,
+    )
+
+
+class PromoteTransactionRequestFilter(RequestFilter):
+  def __init__(self):
+    super(PromoteTransactionRequestFilter, self).__init__({
+      'depth':        f.Required | f.Type(int) | f.Min(1),
+      'transaction':  f.Required | Trytes(result_type=TransactionHash),
+
+      # Loosely-validated; testnet nodes require a different value than
+      # mainnet.
+      'minWeightMagnitude': f.Required | f.Type(int) | f.Min(1),
+    })

--- a/iota/commands/extended/send_transfer.py
+++ b/iota/commands/extended/send_transfer.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function, \
 from typing import List, Optional
 
 import filters as f
-from iota import Address, Bundle, ProposedTransaction
+from iota import Address, Bundle, ProposedTransaction, TransactionHash
 from iota.commands import FilterCommand, RequestFilter
 from iota.commands.extended.prepare_transfer import PrepareTransferCommand
 from iota.commands.extended.send_trytes import SendTrytesCommand
@@ -38,6 +38,7 @@ class SendTransferCommand(FilterCommand):
     min_weight_magnitude  = request['minWeightMagnitude'] # type: int
     seed                  = request['seed'] # type: Seed
     transfers             = request['transfers'] # type: List[ProposedTransaction]
+    reference             = request['reference'] # type: Optional[TransactionHash]
 
     pt_response = PrepareTransferCommand(self.adapter)(
       changeAddress   = change_address,
@@ -50,6 +51,7 @@ class SendTransferCommand(FilterCommand):
       depth               = depth,
       minWeightMagnitude  = min_weight_magnitude,
       trytes              = pt_response['trytes'],
+      reference           = reference,
     )
 
     return {
@@ -82,10 +84,13 @@ class SendTransferRequestFilter(RequestFilter):
         # Note that ``inputs`` is allowed to be an empty array.
         'inputs':
           f.Array | f.FilterRepeater(f.Required | Trytes(result_type=Address)),
+
+        'reference': Trytes(result_type=TransactionHash),
       },
 
       allow_missing_keys = {
         'changeAddress',
         'inputs',
+        'reference',
       },
     )

--- a/iota/commands/extended/send_trytes.py
+++ b/iota/commands/extended/send_trytes.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function, \
 from typing import List
 
 import filters as f
-from iota import TransactionTrytes, TryteString
+from iota import TransactionTrytes, TryteString, TransactionHash
 from iota.commands import FilterCommand, RequestFilter
 from iota.commands.core.attach_to_tangle import AttachToTangleCommand
 from iota.commands.core.get_transactions_to_approve import \
@@ -36,10 +36,14 @@ class SendTrytesCommand(FilterCommand):
     depth                 = request['depth'] # type: int
     min_weight_magnitude  = request['minWeightMagnitude'] # type: int
     trytes                = request['trytes'] # type: List[TryteString]
+    reference             = request['reference'] # type: Optional[TransactionHash]
 
     # Call ``getTransactionsToApprove`` to locate trunk and branch
     # transactions so that we can attach the bundle to the Tangle.
-    gta_response = GetTransactionsToApproveCommand(self.adapter)(depth=depth)
+    gta_response = GetTransactionsToApproveCommand(self.adapter)(
+      depth=depth,
+      reference=reference,
+    )
 
     att_response = AttachToTangleCommand(self.adapter)(
       branchTransaction   = gta_response.get('branchTransaction'),
@@ -72,4 +76,10 @@ class SendTrytesRequestFilter(RequestFilter):
       # Loosely-validated; testnet nodes require a different value than
       # mainnet.
       'minWeightMagnitude': f.Required | f.Type(int) | f.Min(1),
+
+      'reference': Trytes(result_type=TransactionHash),
+    },
+
+    allow_missing_keys = {
+      'reference',
     })

--- a/test/commands/extended/promote_transaction_test.py
+++ b/test/commands/extended/promote_transaction_test.py
@@ -1,0 +1,371 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, \
+  unicode_literals
+
+from unittest import TestCase
+
+import filters as f
+from filters.test import BaseFilterTestCase
+from six import binary_type
+
+from iota import Bundle, Iota, TransactionHash, TransactionTrytes, BadApiResponse
+from iota.adapter import MockAdapter
+from iota.commands.extended.promote_transaction import PromoteTransactionCommand
+from iota.filters import Trytes
+from test import mock
+
+
+class PromoteTransactionRequestFilterTestCase(BaseFilterTestCase):
+  filter_type = PromoteTransactionCommand(MockAdapter()).get_request_filter
+  skip_value_check = True
+
+  # noinspection SpellCheckingInspection
+  def setUp(self):
+    super(PromoteTransactionRequestFilterTestCase, self).setUp()
+
+    self.trytes1 = (
+      b'TESTVALUEONE9DONTUSEINPRODUCTION99999DAU'
+      b'9WFSFWBSFT9QATCXFIIKDVFLHIIJGGFCDYENBEDCF'
+    )
+
+  def test_pass_happy_path(self):
+    """
+    Request is valid.
+    """
+    request = {
+      'depth':              100,
+      'minWeightMagnitude': 18,
+      'transaction':        TransactionHash(self.trytes1),
+    }
+
+    filter_ = self._filter(request)
+
+    self.assertFilterPasses(filter_)
+    self.assertDictEqual(filter_.cleaned_data, request)
+
+  def test_pass_compatible_types(self):
+    """
+    Request contains values that can be converted to the expected
+    types.
+    """
+    filter_ = self._filter({
+      # This can be any TrytesCompatible value.
+      'transaction': binary_type(self.trytes1),
+
+      # These values must still be ints, however.
+      'depth':              100,
+      'minWeightMagnitude': 18,
+    })
+
+    self.assertFilterPasses(filter_)
+    self.assertDictEqual(
+      filter_.cleaned_data,
+
+      {
+        'depth':              100,
+        'minWeightMagnitude': 18,
+        'transaction':        TransactionHash(self.trytes1),
+      },
+    )
+
+  def test_fail_empty(self):
+    """
+    Request is empty.
+    """
+    self.assertFilterErrors(
+      {},
+
+      {
+        'depth':              [f.FilterMapper.CODE_MISSING_KEY],
+        'minWeightMagnitude': [f.FilterMapper.CODE_MISSING_KEY],
+        'transaction':        [f.FilterMapper.CODE_MISSING_KEY],
+      },
+    )
+
+  def test_fail_unexpected_parameters(self):
+    """
+    Request contains unexpected parameters.
+    """
+    self.assertFilterErrors(
+      {
+        'depth':              100,
+        'minWeightMagnitude': 18,
+        'transaction':        TransactionHash(self.trytes1),
+
+        # That's a real nasty habit you got there.
+        'foo': 'bar',
+      },
+
+      {
+        'foo': [f.FilterMapper.CODE_EXTRA_KEY],
+      },
+    )
+
+  def test_fail_transaction_null(self):
+    """
+    ``transaction`` is null.
+    """
+    self.assertFilterErrors(
+      {
+        'transaction': None,
+
+        'depth':              100,
+        'minWeightMagnitude': 18,
+      },
+
+      {
+        'transaction': [f.Required.CODE_EMPTY],
+      },
+    )
+
+  def test_fail_transaction_wrong_type(self):
+    """
+    ``transaction`` is not a TrytesCompatible value.
+    """
+    self.assertFilterErrors(
+      {
+        'transaction': 42,
+
+        'depth':              100,
+        'minWeightMagnitude': 18,
+      },
+
+      {
+        'transaction': [f.Type.CODE_WRONG_TYPE],
+      },
+    )
+
+  def test_fail_transaction_not_trytes(self):
+    """
+    ``transaction`` contains invalid characters.
+    """
+    self.assertFilterErrors(
+      {
+        'transaction': b'not valid; must contain only uppercase and "9"',
+
+        'depth':              100,
+        'minWeightMagnitude': 18,
+      },
+
+      {
+        'transaction': [Trytes.CODE_NOT_TRYTES],
+      },
+    )
+
+  def test_fail_depth_null(self):
+    """
+    ``depth`` is null.
+    """
+    self.assertFilterErrors(
+      {
+        'depth': None,
+
+        'minWeightMagnitude': 18,
+        'transaction':        TransactionHash(self.trytes1),
+      },
+
+      {
+        'depth': [f.Required.CODE_EMPTY],
+      },
+    )
+
+  def test_fail_depth_string(self):
+    """
+    ``depth`` is a string.
+    """
+    self.assertFilterErrors(
+      {
+        # Too ambiguous; it's gotta be an int.
+        'depth': '4',
+
+        'minWeightMagnitude': 18,
+        'transaction':        TransactionHash(self.trytes1),
+      },
+
+      {
+        'depth': [f.Type.CODE_WRONG_TYPE],
+      },
+    )
+
+  def test_fail_depth_float(self):
+    """
+    ``depth`` is a float.
+    """
+    self.assertFilterErrors(
+      {
+        # Even with an empty fpart, float value is not valid.
+        'depth': 8.0,
+
+        'minWeightMagnitude': 18,
+        'transaction':        TransactionHash(self.trytes1),
+      },
+
+      {
+        'depth': [f.Type.CODE_WRONG_TYPE],
+      },
+    )
+
+  def test_fail_depth_too_small(self):
+    """
+    ``depth`` is < 1.
+    """
+    self.assertFilterErrors(
+      {
+        'depth': 0,
+
+        'minWeightMagnitude': 18,
+        'transaction':        TransactionHash(self.trytes1),
+      },
+
+      {
+        'depth': [f.Min.CODE_TOO_SMALL],
+      },
+    )
+
+  def test_fail_min_weight_magnitude_null(self):
+    """
+    ``minWeightMagnitude`` is null.
+    """
+    self.assertFilterErrors(
+      {
+        'minWeightMagnitude': None,
+
+        'depth':        100,
+        'transaction':  TransactionHash(self.trytes1),
+      },
+
+      {
+        'minWeightMagnitude': [f.Required.CODE_EMPTY],
+      },
+    )
+
+  def test_fail_min_weight_magnitude_string(self):
+    """
+    ``minWeightMagnitude`` is a string.
+    """
+    self.assertFilterErrors(
+      {
+        # It's gotta be an int!
+        'minWeightMagnitude': '18',
+
+        'depth':        100,
+        'transaction':  TransactionHash(self.trytes1),
+      },
+
+      {
+        'minWeightMagnitude': [f.Type.CODE_WRONG_TYPE],
+      },
+    )
+
+  def test_fail_min_weight_magnitude_float(self):
+    """
+    ``minWeightMagnitude`` is a float.
+    """
+    self.assertFilterErrors(
+      {
+        # Even with an empty fpart, float values are not valid.
+        'minWeightMagnitude': 18.0,
+
+        'depth':        100,
+        'transaction':  TransactionHash(self.trytes1),
+      },
+
+      {
+        'minWeightMagnitude': [f.Type.CODE_WRONG_TYPE],
+      },
+    )
+
+  def test_fail_min_weight_magnitude_too_small(self):
+    """
+    ``minWeightMagnitude`` is < 1.
+    """
+    self.assertFilterErrors(
+      {
+        'minWeightMagnitude': 0,
+
+        'depth':        100,
+        'transaction':  TransactionHash(self.trytes1),
+      },
+
+      {
+        'minWeightMagnitude': [f.Min.CODE_TOO_SMALL],
+      },
+    )
+
+
+class PromoteTransactionCommandTestCase(TestCase):
+  def setUp(self):
+    super(PromoteTransactionCommandTestCase, self).setUp()
+
+    self.adapter = MockAdapter()
+    self.command = PromoteTransactionCommand(self.adapter)
+
+    self.trytes1 = b'RBTC9D9DCDQAEASBYBCCKBFA'
+    self.trytes2 =\
+      b'CCPCBDVC9DTCEAKDXC9D9DEARCWCPCBDVCTCEAHDWCTCEAKDCDFD9DSCSA'
+
+    self.hash1 = TransactionHash(
+      b'TESTVALUE9DONTUSEINPRODUCTION99999TBPDM9'
+      b'ADFAWCKCSFUALFGETFIFG9UHIEFE9AYESEHDUBDDF'
+    )
+
+  def test_wireup(self):
+    """
+    Verifies that the command is wired-up correctly.
+    """
+    self.assertIsInstance(
+      Iota(self.adapter).promoteTransaction,
+      PromoteTransactionCommand,
+    )
+
+  def test_happy_path(self):
+    """
+    Successfully promoting a bundle.
+    """
+
+    self.adapter.seed_response('checkConsistency', {
+      'state': True,
+    })
+
+    result_bundle = Bundle.from_tryte_strings([
+      TransactionTrytes(self.trytes1),
+      TransactionTrytes(self.trytes2),
+    ])
+    mock_send_transfer = mock.Mock(return_value={
+      'bundle': result_bundle,
+    })
+
+    with mock.patch(
+        'iota.commands.extended.send_transfer.SendTransferCommand._execute',
+        mock_send_transfer,
+    ):
+
+      response = self.command(
+        transaction=self.hash1,
+        depth=3,
+        minWeightMagnitude=16,
+      )
+
+    self.assertDictEqual(
+      response,
+
+      {
+        'bundle': result_bundle,
+      }
+    )
+
+  def test_not_promotable(self):
+    """
+    Bundle isn't promotable.
+    """
+
+    self.adapter.seed_response('checkConsistency', {
+      'state': False,
+    })
+
+    with self.assertRaises(BadApiResponse):
+      response = self.command(
+        transaction=self.hash1,
+        depth=3,
+        minWeightMagnitude=16,
+      )

--- a/test/commands/extended/send_trytes_test.py
+++ b/test/commands/extended/send_trytes_test.py
@@ -8,7 +8,7 @@ import filters as f
 from filters.test import BaseFilterTestCase
 from six import binary_type, text_type
 
-from iota import Iota, TransactionTrytes, TryteString
+from iota import Iota, TransactionTrytes, TryteString, TransactionHash
 from iota.adapter import MockAdapter
 from iota.commands.extended.send_trytes import SendTrytesCommand
 from iota.filters import Trytes
@@ -40,6 +40,8 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
         TransactionTrytes(self.trytes1),
         TransactionTrytes(self.trytes2),
       ],
+
+      'reference': TransactionHash(self.trytes1),
     }
 
     filter_ = self._filter(request)
@@ -58,6 +60,7 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
         binary_type(self.trytes1),
         bytearray(self.trytes2),
       ],
+      'reference': binary_type(self.trytes2),
 
       # These still have to be ints, however.
       'depth':              100,
@@ -76,6 +79,7 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
           TransactionTrytes(self.trytes1),
           TransactionTrytes(self.trytes2),
         ],
+        'reference': TransactionHash(self.trytes2)
       },
     )
 


### PR DESCRIPTION
Resolves part two of https://github.com/iotaledger/iota.lib.py/issues/121

This is slightly different from the JS library in that the JS library takes in the `transfer` as one of the arguments. I thought this was cleaner, but I can change it back to how the JS library works if desired.