### PR TITLE
Fix result type for `get_tips()`

### DIFF
--- a/iota/commands/__init__.py
+++ b/iota/commands/__init__.py
@@ -18,8 +18,12 @@ from iota.exceptions import with_context
 
 __all__ = [
   'BaseCommand',
-  'CustomCommand',
   'command_registry',
+  'discover_commands',
+  'CustomCommand',
+  'FilterCommand',
+  'RequestFilter',
+  'ResponseFilter',
 ]
 
 command_registry = {} # type: Dict[Text, CommandMeta]
@@ -91,7 +95,7 @@ class BaseCommand(with_metaclass(CommandMeta)):
   command = None # Text
 
   def __init__(self, adapter):
-    # type: (BaseAdapter, bool) -> None
+    # type: (BaseAdapter) -> None
     """
     :param adapter:
       Adapter that will send request payloads to the node.

--- a/iota/commands/core/get_tips.py
+++ b/iota/commands/core/get_tips.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import, division, print_function, \
 
 import filters as f
 
-from iota import Address
 from iota.commands import FilterCommand, RequestFilter, ResponseFilter
 from iota.filters import Trytes
+from iota.transaction.types import TransactionHash
 
 __all__ = [
   'GetTipsCommand',
@@ -42,7 +42,7 @@ class GetTipsResponseFilter(ResponseFilter):
           f.Array
         | f.FilterRepeater(
               f.ByteString(encoding='ascii')
-            | Trytes(result_type=Address)
+            | Trytes(result_type=TransactionHash)
           )
       ),
     })

--- a/test/commands/core/get_tips_test.py
+++ b/test/commands/core/get_tips_test.py
@@ -6,9 +6,11 @@ from unittest import TestCase
 
 import filters as f
 from filters.test import BaseFilterTestCase
+
 from iota import Address, Iota
 from iota.adapter import MockAdapter
 from iota.commands.core.get_tips import GetTipsCommand
+from iota.transaction.types import TransactionHash
 
 
 class GetTipsRequestFilterTestCase(BaseFilterTestCase):
@@ -122,4 +124,29 @@ class GetTipsCommandTestCase(TestCase):
     self.assertIsInstance(
       Iota(self.adapter).getTips,
       GetTipsCommand,
+    )
+
+  def test_type_coercion(self):
+    """
+    The result is coerced to the proper type.
+
+    https://github.com/iotaledger/iota.lib.py/issues/130
+    """
+    # noinspection SpellCheckingInspection
+    self.adapter.seed_response('getTips', {
+      'duration': 42,
+      'hashes': [
+        'TESTVALUE9DONTUSEINPRODUCTION99999ANSVWB'
+        'CZ9ABZYUK9YYXFRLROGMCMQHRARDQPNMHHZSZ9999',
+
+        'TESTVALUE9DONTUSEINPRODUCTION99999HCZURL'
+        'NFWEDRFCYHWTYGUEMJLJ9ZIJTFASAVSEAZJGA9999',
+      ],
+    })
+
+    gt_response = Iota(self.adapter).get_tips()
+
+    self.assertEqual(
+      list(map(type, gt_response['hashes'])),
+      [TransactionHash] * 2,
     )


### PR DESCRIPTION
Fixes #130 

`get_tips()['hashes']` is now a `List[TransactionHash]`.