### PR TITLE
Give TryteString a thesaurus

### DIFF
--- a/docs/multisig.rst
+++ b/docs/multisig.rst
@@ -1,18 +1,18 @@
 Multisignature
 ==============
 
-Multisignature transactions are transactions which require multiple signatures before execution. In simplest example it means that, if there is token wallet which require 5 signatures from different parties, all 5 parties must sign spent transaction, before it will be processed. 
+Multisignature transactions are transactions which require multiple signatures before execution. In simplest example it means that, if there is token wallet which require 5 signatures from different parties, all 5 parties must sign spent transaction, before it will be processed.
 
 It is standard functionality in blockchain systems and it is also implemented in IOTA
 
 .. note::
 
-    You can read more about IOTA multisignature on the `wiki`_.  
+    You can read more about IOTA multisignature on the `wiki`_.
 
 Generating multisignature address
 ---------------------------------
 
-In order to use multisignature functionality, a special multisignature address must be created. It is done by adding each key digest in agreed order into digests list. At the end, last participant is converting digests list (Curl state trits) into multisignature address. 
+In order to use multisignature functionality, a special multisignature address must be created. It is done by adding each key digest in agreed order into digests list. At the end, last participant is converting digests list (Curl state trits) into multisignature address.
 
 .. note::
 
@@ -45,8 +45,8 @@ And here is example where digests are converted into multisignature address:
 .. code-block:: python
 
     cma_result =\
-      api_1.create_multisig_address(digests=[digest_1, 
-                                             digest_2, 
+      api_1.create_multisig_address(digests=[digest_1,
+                                             digest_2,
                                              digest_3])
 
     # For consistency, every API command returns a dict, even if it only
@@ -90,7 +90,7 @@ First signer for multisignature wallet is defining address where tokens should b
             # If you'd like, you may include an optional tag and/or
             # message.
             tag = Tag(b'KITTEHS'),
-            message = TryteString.from_string('thanx fur cheezburgers'),
+            message = TryteString.from_unicode('thanx fur cheezburgers'),
           ),
         ],
 
@@ -142,9 +142,9 @@ When trytes are prepared, round of signing must be performed. Order of signing m
 .. note::
 
     After creation, bundle can be optionally validated:
-    
+
     .. code-block:: python
-        
+
         validator = BundleValidator(bundle)
         if not validator.is_valid():
           raise ValueError(
@@ -181,11 +181,11 @@ Full code `example`_.
 
         In order to enable a 2 of 3 multisig, the cosigners need to share their private keys with the other parties in such a way that no single party can sign inputs alone, but that still enables an M-of-N multsig. In our example, the sharing of the private keys would look as follows:
 
-        Alice   ->      Bob 
+        Alice   ->      Bob
 
-        Bob     ->      Carol 
+        Bob     ->      Carol
 
-        Carol   ->      Alice   
+        Carol   ->      Alice
 
         Now, each participant holds two private keys that he/she can use to collude with another party to successfully sign the inputs and make a transaction. But no single party holds enough keys (3 of 3) to be able to independently make the transaction.
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -65,13 +65,13 @@ Encoding
 
     from iota import TryteString
 
-    message_trytes = TryteString.from_string('Hello, IOTA!')
+    message_trytes = TryteString.from_unicode('Hello, IOTA!')
 
 To encode character data into trytes, use the
-``TryteString.from_string`` method.
+``TryteString.from_unicode`` method.
 
 You can also convert a tryte sequence into characters using
-``TryteString.as_string``. Note that not every tryte sequence can be
+``TryteString.decode``. Note that not every tryte sequence can be
 converted; garbage in, garbage out!
 
 .. code:: python
@@ -79,7 +79,7 @@ converted; garbage in, garbage out!
     from iota import TryteString
 
     trytes = TryteString(b'RBTC9D9DCDQAEASBYBCCKBFA')
-    message = trytes.as_string()
+    message = trytes.decode()
 
 .. note::
 
@@ -226,7 +226,7 @@ hasn't been broadcast yet.
             b'EFNDOCQCMERGUATCIEGGOHPHGFIAQEZGNHQ9W99CH'
           ),
 
-        message = TryteString.from_string('thx fur cheezburgers'),
+        message = TryteString.from_unicode('thx fur cheezburgers'),
         tag     = Tag(b'KITTEHS'),
         value   = 42,
       )

--- a/iota/transaction/base.py
+++ b/iota/transaction/base.py
@@ -9,8 +9,8 @@ from typing import Iterable, Iterator, List, MutableSequence, \
 from iota.codecs import TrytesDecodeError
 from iota.crypto import Curl, HASH_LENGTH
 from iota.json import JsonSerializable
-from iota.transaction.types import BundleHash, Fragment, Nonce, TransactionHash, \
-  TransactionTrytes
+from iota.transaction.types import BundleHash, Fragment, Nonce, \
+  TransactionHash, TransactionTrytes
 from iota.trits import int_from_trits, trits_from_int
 from iota.types import Address, Tag, TryteString, TrytesCompatible
 
@@ -485,7 +485,7 @@ class Bundle(JsonSerializable, Sequence[Transaction]):
 
       if message_trytes:
         try:
-          messages.append(message_trytes.as_string(decode_errors))
+          messages.append(message_trytes.decode(decode_errors))
         except (TrytesDecodeError, UnicodeDecodeError):
           if errors != 'drop':
             raise

--- a/iota/types.py
+++ b/iota/types.py
@@ -481,6 +481,12 @@ class TryteString(JsonSerializable):
       - :py:class:`iota.codecs.TrytesDecodeError` if the trytes cannot
         be decoded into bytes.
     """
+    # Converting ASCII-encoded trytes into bytes is considered to be a
+    # *decode* operation according to :py:class:`AsciiTrytesCodec`.
+    # Once we add more codecs, we may need to revisit this.
+    # See https://github.com/iotaledger/iota.lib.py/issues/62 for more
+    # information.
+    #
     # In Python 2, :py:func:`decode` does not accept keyword arguments.
     return decode(self._trytes, codec, errors)
 

--- a/test/commands/extended/prepare_transfer_test.py
+++ b/test/commands/extended/prepare_transfer_test.py
@@ -1132,7 +1132,7 @@ class PrepareTransferCommandTestCase(TestCase):
               'VNDMLXPT9HMVAOWUUZMLSJZFWGKDVGXPSQAWAEBJN'
             ),
 
-          message = TryteString.from_string('สวัสดีชาวโลก!'),
+          message = TryteString.from_unicode('สวัสดีชาวโลก!'),
           tag     = Tag('PYOTA9UNIT9TESTS9'),
           value   = 0,
         ),
@@ -1168,7 +1168,7 @@ class PrepareTransferCommandTestCase(TestCase):
               ),
 
             message =
-              TryteString.from_string(
+              TryteString.from_unicode(
                 'Вы не можете справиться правду! Сын, мы живем в мире, который '
                 'имеет стены. И эти стены должны быть охраняют люди с оружием. '
                 'Кто будет это делать? Вы? Вы, лейтенант Weinberg? У меня есть '

--- a/test/transaction/base_test.py
+++ b/test/transaction/base_test.py
@@ -4,8 +4,8 @@ from __future__ import absolute_import, division, print_function, \
 
 from unittest import TestCase
 
-from iota import Address, Bundle, BundleHash, Fragment, Hash, \
-  Tag, Transaction, TransactionHash, TransactionTrytes, TryteString, Nonce
+from iota import Address, Bundle, BundleHash, Fragment, Hash, Nonce, Tag, \
+  Transaction, TransactionHash, TransactionTrytes
 
 
 class BundleTestCase(TestCase):
@@ -74,7 +74,7 @@ class BundleTestCase(TestCase):
       # fragment.
       Transaction(
         signature_message_fragment =
-          Fragment.from_string('Hello, world!'),
+          Fragment.from_unicode('Hello, world!'),
 
         address =
           Address(
@@ -207,7 +207,7 @@ class BundleTestCase(TestCase):
         # Make the signature look like a message, so we can verify that
         # the Bundle skips it correctly.
         signature_message_fragment =
-          Fragment.from_string('This is a signature, not a message!'),
+          Fragment.from_unicode('This is a signature, not a message!'),
 
         address =
           Address(
@@ -237,7 +237,7 @@ class BundleTestCase(TestCase):
         # Make the signature look like a message, so we can verify that
         # the Bundle skips it correctly.
         signature_message_fragment =
-          Fragment.from_string('This is a signature, not a message!'),
+          Fragment.from_unicode('This is a signature, not a message!'),
 
         address =
           Address(
@@ -267,7 +267,7 @@ class BundleTestCase(TestCase):
         # It's unusual for a change transaction to have a message, but
         # half the fun of unit tests is designing unusual scenarios!
         signature_message_fragment =
-          Fragment.from_string('I can haz change?'),
+          Fragment.from_unicode('I can haz change?'),
 
         address =
           Address(
@@ -534,7 +534,7 @@ class TransactionTestCase(TestCase):
         b'QZUIJDFPTTCTKBJRHAITVSKUCUEMD9M9SQJ999999'
       ),
     )
-    
+
     self.assertEqual(transaction.tag, Tag(b'999999999999999999999999999'))
     self.assertEqual(transaction.attachment_timestamp,1480690413)
     self.assertEqual(transaction.attachment_timestamp_lower_bound,1480690413)
@@ -642,12 +642,12 @@ class TransactionTestCase(TestCase):
           b'TKORV9IKTJZQUBQAWTKBKZ9NEZHBFIMCLV9TTNJN'
           b'QZUIJDFPTTCTKBJRHAITVSKUCUEMD9M9SQJ999999'
         ),
-        
+
       tag                               = Tag(b'999999999999999999999999999'),
       attachment_timestamp              = 1480690413,
       attachment_timestamp_lower_bound  = 1480690413,
       attachment_timestamp_upper_bound  = 1480690413,
-      
+
 
       nonce =
         Nonce(

--- a/test/transaction/creation_test.py
+++ b/test/transaction/creation_test.py
@@ -115,7 +115,7 @@ class ProposedBundleTestCase(TestCase):
           b'D9YBTH9EMFKF9CAHJIAIKDBEPAMH99DEN9DAJETGN'
         ),
 
-      message = TryteString.from_string('Hello, IOTA!'),
+      message = TryteString.from_unicode('Hello, IOTA!'),
       value   = 42,
     ))
 
@@ -134,13 +134,13 @@ class ProposedBundleTestCase(TestCase):
       b'HCFIUGLBSCKELC9IYENFPHCEWHIDCHCGGEH9OFZBN'
     )
 
-    tag = Tag.from_string('H2G2')
+    tag = Tag.from_unicode('H2G2')
 
     self.bundle.add_transaction(ProposedTransaction(
       address = address,
       tag     = tag,
 
-      message = TryteString.from_string(
+      message = TryteString.from_unicode(
         '''
 "Good morning," said Deep Thought at last.
 "Er... Good morning, O Deep Thought," said Loonquawl nervously.


### PR DESCRIPTION
Fixes #90 

- Rename `TryteString.from_string` to `from_unicode`.
- Rename `TryteString.as_bytes` to `encode`.
- Rename `TryteString.as_string` to `decode`.
- Add deprecated versions of the renamed functions.