### PR TITLE
Release/2.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ python:
   - '3.5'
   - '3.6'
 install: pip install .
-script: nosetests
+script:
+  - python setup.py check --strict --metadata --restructuredtext
+  - nosetests
 deploy:
   on:
     python: '3.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ python:
   - '2.7'
   - '3.5'
   - '3.6'
-install: pip install .
+install:
+  - pip install .
+  - pip install docutils # Used to check package metadata.
 script:
   - python setup.py check --strict --metadata --restructuredtext
   - nosetests

--- a/README.rst
+++ b/README.rst
@@ -58,10 +58,17 @@ To run unit tests after installing from source::
 
   python setup.py test
 
-PyOTA is also compatible with `tox`_::
+PyOTA is also compatible with `tox`_, which will run the unit tests in different
+virtual environments (one for each supported version of Python).
 
-  pip install tox
-  tox
+To run the unit tests, it is recommended that you use the `detox`_ library.
+detox speeds up the tests by running them in parallel.
+
+Install PyOTA with the ``test-runner`` extra to set up the necessary
+dependencies, and then you can run the tests with the ``detox`` command::
+
+  pip install -e .[test-runner]
+  detox -v
 
 =============
 Documentation
@@ -95,5 +102,6 @@ can also build the documentation locally:
 .. _ReadTheDocs: https://pyota.readthedocs.io/
 .. _Slack: https://slack.iota.org/
 .. _dedicated forum: https://forum.iota.org/
+.. _detox: https://pypi.python.org/pypi/detox
 .. _official API: https://iota.readme.io/
 .. _tox: https://tox.readthedocs.io/

--- a/README.rst
+++ b/README.rst
@@ -45,8 +45,6 @@ To install this extension, use the following command::
    pip install pyota[ccurl]
 
 
-.. _readme-installing-from-source:
-
 Installing from Source
 ======================
 
@@ -70,7 +68,7 @@ Documentation
 =============
 PyOTA's documentation is available on `ReadTheDocs`_.
 
-If you are :ref:`installing from source <readme-installing-from-source>`, you
+If you are installing from source (see above), you
 can also build the documentation locally:
 
 #. Install extra dependencies (you only have to do this once)::

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Join the Discussion
 ===================
 If you want to get involved in the community, need help with getting setup,
 have any issues related with the library or just want to discuss Blockchain,
-Distributed Ledgers and IoT with other people, feel free to join our `Slack`_.
+Distributed Ledgers and IoT with other people, feel free to join our `Discord`_.
 
 You can also ask questions on our `dedicated forum`_.
 
@@ -98,9 +98,9 @@ can also build the documentation locally:
       make html
 
 .. _Create virtualenv: https://realpython.com/blog/python/python-virtual-environments-a-primer/
+.. _Discord: https://discordapp.com/invite/yxve4wu
 .. _PyOTA Bug Tracker: https://github.com/iotaledger/iota.lib.py/issues
 .. _ReadTheDocs: https://pyota.readthedocs.io/
-.. _Slack: https://slack.iota.org/
 .. _dedicated forum: https://forum.iota.org/
 .. _detox: https://pypi.python.org/pypi/detox
 .. _official API: https://iota.readme.io/

--- a/docs/adapters.rst
+++ b/docs/adapters.rst
@@ -44,6 +44,13 @@ HttpAdapter
     api = Iota('https://service.iotasupport.com:14265')
     api = Iota(HttpAdapter('https://service.iotasupport.com:14265'))
 
+    # Use HTTPS with basic authentication and 60 seconds timeout:
+    api = Iota(
+        HttpAdapter(
+            'https://service.iotasupport.com:14265',
+            authentication=('myusername', 'mypassword'),
+            timeout=60))
+
 ``HttpAdapter`` uses the HTTP protocol to send requests to the node.
 
 To configure an ``Iota`` instance to use ``HttpAdapter``, specify an

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,14 +1,14 @@
-Standard API
-============
+Core API
+========
 
-The Standard API includes all of the core API calls that are made
+The Core API includes all of the core API calls that are made
 available by the current `IOTA Reference
 Implementation <https://github.com/iotaledger/iri>`__.
 
 These methods are "low level" and generally do not need to be called
 directly.
 
-For the full documentation of all the Standard API calls, please refer
+For the full documentation of all the Core API calls, please refer
 to the `official documentation <https://iota.readme.io/>`__.
 
 Extended API

--- a/docs/multisig.rst
+++ b/docs/multisig.rst
@@ -1,18 +1,18 @@
 Multisignature
 ==============
 
-Multisignature transactions are transactions which require multiple signatures before execution. In simplest example it means that, if there is token wallet which require 5 signatures from different parties, all 5 parties must sign spent transaction, before it will be processed. 
+Multisignature transactions are transactions which require multiple signatures before execution. In simplest example it means that, if there is token wallet which require 5 signatures from different parties, all 5 parties must sign spent transaction, before it will be processed.
 
 It is standard functionality in blockchain systems and it is also implemented in IOTA
 
 .. note::
 
-    You can read more about IOTA multisignature on the `wiki`_.  
+    You can read more about IOTA multisignature on the `wiki`_.
 
 Generating multisignature address
 ---------------------------------
 
-In order to use multisignature functionality, a special multisignature address must be created. It is done by adding each key digest in agreed order into digests list. At the end, last participant is converting digests list (Curl state trits) into multisignature address. 
+In order to use multisignature functionality, a special multisignature address must be created. It is done by adding each key digest in agreed order into digests list. At the end, last participant is converting digests list (Curl state trits) into multisignature address.
 
 .. note::
 
@@ -45,8 +45,8 @@ And here is example where digests are converted into multisignature address:
 .. code-block:: python
 
     cma_result =\
-      api_1.create_multisig_address(digests=[digest_1, 
-                                             digest_2, 
+      api_1.create_multisig_address(digests=[digest_1,
+                                             digest_2,
                                              digest_3])
 
     # For consistency, every API command returns a dict, even if it only
@@ -90,7 +90,7 @@ First signer for multisignature wallet is defining address where tokens should b
             # If you'd like, you may include an optional tag and/or
             # message.
             tag = Tag(b'KITTEHS'),
-            message = TryteString.from_string('thanx fur cheezburgers'),
+            message = TryteString.from_unicode('thanx fur cheezburgers'),
           ),
         ],
 
@@ -142,9 +142,9 @@ When trytes are prepared, round of signing must be performed. Order of signing m
 .. note::
 
     After creation, bundle can be optionally validated:
-    
+
     .. code-block:: python
-        
+
         validator = BundleValidator(bundle)
         if not validator.is_valid():
           raise ValueError(
@@ -181,11 +181,11 @@ Full code `example`_.
 
         In order to enable a 2 of 3 multisig, the cosigners need to share their private keys with the other parties in such a way that no single party can sign inputs alone, but that still enables an M-of-N multsig. In our example, the sharing of the private keys would look as follows:
 
-        Alice   ->      Bob 
+        Alice   ->      Bob
 
-        Bob     ->      Carol 
+        Bob     ->      Carol
 
-        Carol   ->      Alice   
+        Carol   ->      Alice
 
         Now, each participant holds two private keys that he/she can use to collude with another party to successfully sign the inputs and make a transaction. But no single party holds enough keys (3 of 3) to be able to independently make the transaction.
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -65,13 +65,13 @@ Encoding
 
     from iota import TryteString
 
-    message_trytes = TryteString.from_string('Hello, IOTA!')
+    message_trytes = TryteString.from_unicode('Hello, IOTA!')
 
 To encode character data into trytes, use the
-``TryteString.from_string`` method.
+``TryteString.from_unicode`` method.
 
 You can also convert a tryte sequence into characters using
-``TryteString.as_string``. Note that not every tryte sequence can be
+``TryteString.decode``. Note that not every tryte sequence can be
 converted; garbage in, garbage out!
 
 .. code:: python
@@ -79,7 +79,7 @@ converted; garbage in, garbage out!
     from iota import TryteString
 
     trytes = TryteString(b'RBTC9D9DCDQAEASBYBCCKBFA')
-    message = trytes.as_string()
+    message = trytes.decode()
 
 .. note::
 
@@ -226,7 +226,7 @@ hasn't been broadcast yet.
             b'EFNDOCQCMERGUATCIEGGOHPHGFIAQEZGNHQ9W99CH'
           ),
 
-        message = TryteString.from_string('thx fur cheezburgers'),
+        message = TryteString.from_unicode('thx fur cheezburgers'),
         tag     = Tag(b'KITTEHS'),
         value   = 42,
       )

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -158,6 +158,9 @@ Each ``Transaction`` has the following attributes:
 -  ``address: Address``: The address associated with this transaction.
    Depending on the transaction's ``value``, this address may be a
    sender or a recipient.
+-  ``attachment_timestamp: int``: Estimated epoch time of the attachment to the tangle.
+-  ``attachment_time_lower_bound: int``: The lowest possible epoch time of the attachment to the tangle.
+-  ``attachment_time_upper_bound: int``: The highest possible epoch time of the attachment to the tangle.
 -  ``branch_transaction_hash: TransactionHash``: An unrelated
    transaction that this transaction "approves". Refer to the Basic
    Concepts section for more information.
@@ -179,6 +182,7 @@ Each ``Transaction`` has the following attributes:
 -  ``last_index: int``: The index of the final transaction in the
    bundle. This value is attached to every transaction to make it easier
    to traverse and verify bundles.
+-  ``legacy_tag: Tag``: A short message attached to the transaction. Deprecated, use ``tag`` instead.
 -  ``nonce: Hash``: This is the product of the PoW process.
 -  ``signature_message_fragment: Fragment``: Additional data attached to
    the transaction:

--- a/examples/send_transfer.py
+++ b/examples/send_transfer.py
@@ -4,6 +4,8 @@ Example script that shows how to use PyOTA to send a transfer to an address.
 """
 from iota import *
 
+SEED1 = b"THESEEDOFTHEWALLETSENDINGGOESHERE999999999999999999999999999999999999999999999999"
+ADDRESS_WITH_CHECKSUM_SECURITY_LEVEL_2 = b"RECEIVINGWALLETADDRESSGOESHERE9WITHCHECKSUMANDSECURITYLEVEL2999999999999999999999999999999"
 
 # Create the API instance.
 api =\
@@ -12,7 +14,7 @@ api =\
     'http://localhost:14265/',
 
     # Seed used for cryptographic functions.
-    seed = b'SEED9GOES9HERE'
+    seed = SEED1
   )
 
 # For more information, see :py:meth:`Iota.send_transfer`.
@@ -26,8 +28,7 @@ api.send_transfer(
       # Recipient of the transfer.
       address =
         Address(
-          b'TESTVALUE9DONTUSEINPRODUCTION99999FBFFTG'
-          b'QFWEHEL9KCAFXBJBXGE9HID9XCOHFIDABHDG9AHDR'
+          ADDRESS_WITH_CHECKSUM_SECURITY_LEVEL_2,
         ),
 
       # Amount of IOTA to transfer.

--- a/iota/adapter/__init__.py
+++ b/iota/adapter/__init__.py
@@ -10,7 +10,7 @@ from logging import DEBUG, Logger
 from socket import getdefaulttimeout as get_default_timeout
 from typing import Container, Dict, List, Optional, Text, Tuple, Union
 
-from requests import Response, codes, request
+from requests import Response, codes, request, auth
 from six import PY2, binary_type, iteritems, moves as compat, text_type, \
   with_metaclass
 
@@ -223,11 +223,12 @@ class HttpAdapter(BaseAdapter):
   in the ``headers`` kwarg.
   """
 
-  def __init__(self, uri, timeout=None):
+  def __init__(self, uri, timeout=None, authentication=None):
     # type: (Union[Text, SplitResult], Optional[int]) -> None
     super(HttpAdapter, self).__init__()
 
     self.timeout = timeout
+    self.authentication = authentication
 
     if isinstance(uri, text_type):
       uri = compat.urllib_parse.urlsplit(uri) # type: SplitResult
@@ -313,6 +314,8 @@ class HttpAdapter(BaseAdapter):
 
     default_timeout = self.timeout if self.timeout else get_default_timeout()
     kwargs.setdefault('timeout', default_timeout)
+    if self.authentication:
+        kwargs.setdefault('auth', auth.HTTPBasicAuth(*self.authentication))
 
     self._log(
       level = DEBUG,

--- a/iota/adapter/__init__.py
+++ b/iota/adapter/__init__.py
@@ -223,9 +223,11 @@ class HttpAdapter(BaseAdapter):
   in the ``headers`` kwarg.
   """
 
-  def __init__(self, uri):
-    # type: (Union[Text, SplitResult]) -> None
+  def __init__(self, uri, timeout=None):
+    # type: (Union[Text, SplitResult], Optional[int]) -> None
     super(HttpAdapter, self).__init__()
+
+    self.timeout = timeout
 
     if isinstance(uri, text_type):
       uri = compat.urllib_parse.urlsplit(uri) # type: SplitResult
@@ -308,7 +310,9 @@ class HttpAdapter(BaseAdapter):
     Split into its own method so that it can be mocked during unit
     tests.
     """
-    kwargs.setdefault('timeout', get_default_timeout())
+
+    default_timeout = self.timeout if self.timeout else get_default_timeout()
+    kwargs.setdefault('timeout', default_timeout)
 
     self._log(
       level = DEBUG,

--- a/iota/api.py
+++ b/iota/api.py
@@ -775,6 +775,33 @@ class Iota(StrictIota):
       changeAddress = change_address,
     )
 
+  def promote_transaction(
+      self,
+      transaction,
+      depth,
+      min_weight_magnitude = None,
+  ):
+    # type: (TransactionHash, int, Optional[int]) -> dict
+    """
+    Promotes a transaction by adding spam on top of it.
+
+    :return:
+      Dict containing the following values::
+
+         {
+           'bundle': Bundle,
+             The newly-published bundle.
+         }
+    """
+    if min_weight_magnitude is None:
+        min_weight_magnitude = self.default_min_weight_magnitude
+
+    return extended.PromoteTransactionCommand(self.adapter)(
+      transaction         = transaction,
+      depth               = depth,
+      minWeightMagnitude  = min_weight_magnitude,
+    )
+
   def replay_bundle(
       self,
       transaction,

--- a/iota/api.py
+++ b/iota/api.py
@@ -943,3 +943,27 @@ class Iota(StrictIota):
       depth               = depth,
       minWeightMagnitude  = min_weight_magnitude,
     )
+
+  def is_reattachable(self, addresses):
+    # type: (Iterable[Address]) -> dict
+    """
+    This API function helps you to determine whether you should replay a
+     transaction or make a completely new transaction with a different seed.
+     What this function does, is it takes one or more input addresses (i.e. from spent transactions)
+     as input and then checks whether any transactions with a value transferred are confirmed.
+     If yes, it means that this input address has already been successfully used in a different
+     transaction and as such you should no longer replay the transaction.
+
+    :param addresses:
+      List of addresses.
+
+    :return:
+      Dict containing the following values::
+         {
+           'reattachable': List[bool],
+           Always a list, even if only one address was queried.
+         }
+    """
+    return extended.IsReattachableCommand(self.adapter)(
+      addresses=addresses
+    )

--- a/iota/api.py
+++ b/iota/api.py
@@ -9,6 +9,7 @@ from iota import AdapterSpec, Address, ProposedTransaction, Tag, \
 from iota.adapter import BaseAdapter, resolve_adapter
 from iota.commands import BaseCommand, CustomCommand, core, \
   discover_commands, extended
+from iota.commands.extended.helpers import Helpers
 from iota.crypto.addresses import AddressGenerator
 from iota.crypto.types import Seed
 from six import with_metaclass
@@ -440,6 +441,7 @@ class Iota(StrictIota):
     super(Iota, self).__init__(adapter, testnet)
 
     self.seed = Seed(seed) if seed else Seed.random()
+    self.helpers = Helpers(self)
 
   def broadcast_and_store(self, trytes):
     # type: (Iterable[TransactionTrytes]) -> dict

--- a/iota/commands/__init__.py
+++ b/iota/commands/__init__.py
@@ -18,8 +18,12 @@ from iota.exceptions import with_context
 
 __all__ = [
   'BaseCommand',
-  'CustomCommand',
   'command_registry',
+  'discover_commands',
+  'CustomCommand',
+  'FilterCommand',
+  'RequestFilter',
+  'ResponseFilter',
 ]
 
 command_registry = {} # type: Dict[Text, CommandMeta]
@@ -91,7 +95,7 @@ class BaseCommand(with_metaclass(CommandMeta)):
   command = None # Text
 
   def __init__(self, adapter):
-    # type: (BaseAdapter, bool) -> None
+    # type: (BaseAdapter) -> None
     """
     :param adapter:
       Adapter that will send request payloads to the node.

--- a/iota/commands/core/get_tips.py
+++ b/iota/commands/core/get_tips.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import, division, print_function, \
 
 import filters as f
 
-from iota import Address
 from iota.commands import FilterCommand, RequestFilter, ResponseFilter
 from iota.filters import Trytes
+from iota.transaction.types import TransactionHash
 
 __all__ = [
   'GetTipsCommand',
@@ -42,7 +42,7 @@ class GetTipsResponseFilter(ResponseFilter):
           f.Array
         | f.FilterRepeater(
               f.ByteString(encoding='ascii')
-            | Trytes(result_type=Address)
+            | Trytes(result_type=TransactionHash)
           )
       ),
     })

--- a/iota/commands/core/get_transactions_to_approve.py
+++ b/iota/commands/core/get_transactions_to_approve.py
@@ -32,7 +32,25 @@ class GetTransactionsToApproveRequestFilter(RequestFilter):
   def __init__(self):
     super(GetTransactionsToApproveRequestFilter, self).__init__({
       'depth': f.Required | f.Type(int) | f.Min(1),
+
+      'reference': Trytes(result_type=TransactionHash),
+    },
+
+    allow_missing_keys = {
+      'reference',
     })
+
+  def _apply(self, value):
+    value = super(GetTransactionsToApproveRequestFilter, self)._apply(value) # type: dict
+
+    if self._has_errors:
+      return value
+
+    # Remove reference if null.
+    if value['reference'] is None:
+      del value['reference']
+
+    return value
 
 
 class GetTransactionsToApproveResponseFilter(ResponseFilter):

--- a/iota/commands/extended/__init__.py
+++ b/iota/commands/extended/__init__.py
@@ -19,6 +19,7 @@ from .get_latest_inclusion import *
 from .get_new_addresses import *
 from .get_transfers import *
 from .prepare_transfer import *
+from .promote_transaction import *
 from .replay_bundle import *
 from .send_transfer import *
 from .send_trytes import *

--- a/iota/commands/extended/__init__.py
+++ b/iota/commands/extended/__init__.py
@@ -18,6 +18,7 @@ from .get_inputs import *
 from .get_latest_inclusion import *
 from .get_new_addresses import *
 from .get_transfers import *
+from .is_reattachable import *
 from .prepare_transfer import *
 from .promote_transaction import *
 from .replay_bundle import *

--- a/iota/commands/extended/helpers.py
+++ b/iota/commands/extended/helpers.py
@@ -1,0 +1,18 @@
+class Helpers(object):
+  """
+  Adds additional helper functions that aren't part of the core or extended
+  API.
+  """
+
+  def __init__(self, api):
+    self.api = api
+
+  def is_promotable(self, tail):
+    # type: (TransactionHash) -> bool
+    """
+    Determines if a tail transaction is promotable.
+
+    :param tail:
+      Transaction hash. Must be a tail transaction.
+    """
+    return self.api.check_consistency(tails=[tail])['state']

--- a/iota/commands/extended/is_reattachable.py
+++ b/iota/commands/extended/is_reattachable.py
@@ -1,0 +1,75 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, unicode_literals
+from typing import List
+
+import filters as f
+
+from iota import Address
+from iota.commands import FilterCommand, RequestFilter, ResponseFilter
+from iota.commands.extended import GetLatestInclusionCommand
+from iota.commands.extended.utils import find_transaction_objects
+from iota.filters import Trytes
+
+__all__ = [
+  'IsReattachableCommand',
+]
+
+
+class IsReattachableCommand(FilterCommand):
+  """
+  Executes ``isReattachable`` extended API command.
+  """
+  command = 'isReattachable'
+
+  def get_request_filter(self):
+    return IsReattachableRequestFilter()
+
+  def get_response_filter(self):
+    return IsReattachableResponseFilter()
+
+  def _execute(self, request):
+    addresses = request['addresses']  # type: List[Address]
+
+    # fetch full transaction objects
+    transactions = find_transaction_objects(adapter=self.adapter, **{'addresses': addresses})
+
+    # map and filter transactions, which have zero value.
+    # If multiple transactions for the same address are returned the one with the
+    # highest attachment_timestamp is selected
+    transactions = sorted(transactions, key=lambda t: t.attachment_timestamp)
+    transaction_map = {t.address: t.hash for t in transactions if t.value > 0}
+
+    # fetch inclusion states
+    inclusion_states = GetLatestInclusionCommand(adapter=self.adapter)(hashes=list(transaction_map.values()))
+    inclusion_states = inclusion_states['states']
+
+    return {
+      'reattachable': [not inclusion_states[transaction_map[address]] for address in addresses]
+    }
+
+
+class IsReattachableRequestFilter(RequestFilter):
+  def __init__(self):
+    super(IsReattachableRequestFilter, self).__init__(
+      {
+        'addresses': (
+          f.Required
+          | f.Array
+          | f.FilterRepeater(
+            f.Required
+            | Trytes(result_type=Address)
+            | f.Unicode(encoding='ascii', normalize=False)
+          )
+        )
+      }
+    )
+
+
+class IsReattachableResponseFilter(ResponseFilter):
+  def __init__(self):
+    super(IsReattachableResponseFilter, self).__init__({
+      'reattachable': (
+        f.Required
+        | f.Array
+        | f.FilterRepeater(f.Type(bool)))
+    })

--- a/iota/commands/extended/promote_transaction.py
+++ b/iota/commands/extended/promote_transaction.py
@@ -1,0 +1,68 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, \
+  unicode_literals
+
+import filters as f
+from iota import (
+  Bundle, TransactionHash, Address, ProposedTransaction, BadApiResponse,
+)
+from iota.commands import FilterCommand, RequestFilter
+from iota.commands.core.check_consistency import CheckConsistencyCommand
+from iota.commands.extended.send_transfer import SendTransferCommand
+from iota.filters import Trytes
+
+__all__ = [
+  'PromoteTransactionCommand',
+]
+
+
+class PromoteTransactionCommand(FilterCommand):
+  """
+  Executes ``promoteTransaction`` extended API command.
+
+  See :py:meth:`iota.api.Iota.promote_transaction` for more information.
+  """
+  command = 'promoteTransaction'
+
+  def get_request_filter(self):
+    return PromoteTransactionRequestFilter()
+
+  def get_response_filter(self):
+    pass
+
+  def _execute(self, request):
+    depth                 = request['depth'] # type: int
+    min_weight_magnitude  = request['minWeightMagnitude'] # type: int
+    transaction           = request['transaction'] # type: TransactionHash
+
+    cc_response = CheckConsistencyCommand(self.adapter)(tails=[transaction])
+    if cc_response['state'] is False:
+      raise BadApiResponse(
+        'Transaction {transaction} is not promotable. '
+        'You should reattach first.'.format(transaction=transaction)
+      )
+
+    spam_transfer = ProposedTransaction(
+      address=Address(b''),
+      value=0,
+    )
+
+    return SendTransferCommand(self.adapter)(
+      seed=spam_transfer.address,
+      depth=depth,
+      transfers=[spam_transfer],
+      minWeightMagnitude=min_weight_magnitude,
+      reference=transaction,
+    )
+
+
+class PromoteTransactionRequestFilter(RequestFilter):
+  def __init__(self):
+    super(PromoteTransactionRequestFilter, self).__init__({
+      'depth':        f.Required | f.Type(int) | f.Min(1),
+      'transaction':  f.Required | Trytes(result_type=TransactionHash),
+
+      # Loosely-validated; testnet nodes require a different value than
+      # mainnet.
+      'minWeightMagnitude': f.Required | f.Type(int) | f.Min(1),
+    })

--- a/iota/commands/extended/send_transfer.py
+++ b/iota/commands/extended/send_transfer.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function, \
 from typing import List, Optional
 
 import filters as f
-from iota import Address, Bundle, ProposedTransaction
+from iota import Address, Bundle, ProposedTransaction, TransactionHash
 from iota.commands import FilterCommand, RequestFilter
 from iota.commands.extended.prepare_transfer import PrepareTransferCommand
 from iota.commands.extended.send_trytes import SendTrytesCommand
@@ -38,6 +38,7 @@ class SendTransferCommand(FilterCommand):
     min_weight_magnitude  = request['minWeightMagnitude'] # type: int
     seed                  = request['seed'] # type: Seed
     transfers             = request['transfers'] # type: List[ProposedTransaction]
+    reference             = request['reference'] # type: Optional[TransactionHash]
 
     pt_response = PrepareTransferCommand(self.adapter)(
       changeAddress   = change_address,
@@ -50,6 +51,7 @@ class SendTransferCommand(FilterCommand):
       depth               = depth,
       minWeightMagnitude  = min_weight_magnitude,
       trytes              = pt_response['trytes'],
+      reference           = reference,
     )
 
     return {
@@ -82,10 +84,13 @@ class SendTransferRequestFilter(RequestFilter):
         # Note that ``inputs`` is allowed to be an empty array.
         'inputs':
           f.Array | f.FilterRepeater(f.Required | Trytes(result_type=Address)),
+
+        'reference': Trytes(result_type=TransactionHash),
       },
 
       allow_missing_keys = {
         'changeAddress',
         'inputs',
+        'reference',
       },
     )

--- a/iota/commands/extended/send_trytes.py
+++ b/iota/commands/extended/send_trytes.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function, \
 from typing import List
 
 import filters as f
-from iota import TransactionTrytes, TryteString
+from iota import TransactionTrytes, TryteString, TransactionHash
 from iota.commands import FilterCommand, RequestFilter
 from iota.commands.core.attach_to_tangle import AttachToTangleCommand
 from iota.commands.core.get_transactions_to_approve import \
@@ -36,10 +36,14 @@ class SendTrytesCommand(FilterCommand):
     depth                 = request['depth'] # type: int
     min_weight_magnitude  = request['minWeightMagnitude'] # type: int
     trytes                = request['trytes'] # type: List[TryteString]
+    reference             = request['reference'] # type: Optional[TransactionHash]
 
     # Call ``getTransactionsToApprove`` to locate trunk and branch
     # transactions so that we can attach the bundle to the Tangle.
-    gta_response = GetTransactionsToApproveCommand(self.adapter)(depth=depth)
+    gta_response = GetTransactionsToApproveCommand(self.adapter)(
+      depth=depth,
+      reference=reference,
+    )
 
     att_response = AttachToTangleCommand(self.adapter)(
       branchTransaction   = gta_response.get('branchTransaction'),
@@ -72,4 +76,10 @@ class SendTrytesRequestFilter(RequestFilter):
       # Loosely-validated; testnet nodes require a different value than
       # mainnet.
       'minWeightMagnitude': f.Required | f.Type(int) | f.Min(1),
+
+      'reference': Trytes(result_type=TransactionHash),
+    },
+
+    allow_missing_keys = {
+      'reference',
     })

--- a/iota/commands/extended/utils.py
+++ b/iota/commands/extended/utils.py
@@ -17,7 +17,7 @@ from iota.crypto.types import Seed
 
 
 def find_transaction_objects(adapter, **kwargs):
-    # type: (BaseAdapter, dict) -> List[Transaction]
+    # type: (BaseAdapter, **Iterable) -> List[Transaction]
     """
     Finds transactions matching the specified criteria, fetches the
     corresponding trytes and converts them into Transaction objects.

--- a/iota/crypto/pycurl.py
+++ b/iota/crypto/pycurl.py
@@ -140,7 +140,7 @@ class Curl(object):
     # Ensure length can be mod by HASH_LENGTH
     if length % HASH_LENGTH != 0:
       raise with_context(
-        exc = ValueError('Invalid length passed to ``sequeeze`.'),
+        exc = ValueError('Invalid length passed to ``squeeze`.'),
         context = {
           'trits': trits,
           'offset': offset,

--- a/iota/crypto/pycurl.py
+++ b/iota/crypto/pycurl.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import, division, print_function, \
 
 from typing import List, MutableSequence, Optional, Sequence
 
+from iota.exceptions import with_context
+
 __all__ = [
   'Curl',
   'HASH_LENGTH',
@@ -59,16 +61,35 @@ class Curl(object):
     """
     self._state = [0] * STATE_LENGTH # type: List[int]
 
-  def absorb(self, trits):
-    # type: (Sequence[int], Optional[int]) -> None
+  def absorb(self, trits, offset=0, length=None):
+    # type: (Sequence[int], Optional[int], Optional[int]) -> None
     """
     Absorb trits into the sponge.
 
     :param trits:
       Sequence of trits to absorb.
+
+    :param offset:
+      Starting offset in ``trits``.
+
+    :param length:
+      Number of trits to absorb.  Defaults to ``len(trits)``.
     """
-    length  = len(trits)
-    offset  = 0
+    pad = ((len(trits) % HASH_LENGTH) or HASH_LENGTH)
+    trits += [0] * (HASH_LENGTH - pad)
+
+    if length is None:
+      length = len(trits)
+
+    if length < 1:
+      raise with_context(
+        exc = ValueError('Invalid length passed to ``absorb``.'),
+        context = {
+          'trits': trits,
+          'offset': offset,
+          'length': length,
+        },
+      )
 
     # Copy trits from ``trits`` into internal state, one hash at a
     # time, transforming internal state in between hashes.
@@ -92,14 +113,20 @@ class Curl(object):
       # Move on to the next hash.
       offset += HASH_LENGTH
 
-  def squeeze(self, trits):
-    # type: (MutableSequence[int]) -> None
+  def squeeze(self, trits, offset=0, length=HASH_LENGTH):
+    # type: (MutableSequence[int], Optional[int], Optional[int]) -> None
     """
     Squeeze trits from the sponge.
 
     :param trits:
       Sequence that the squeezed trits will be copied to.
       Note: this object will be modified!
+
+    :param offset:
+      Starting offset in ``trits``.
+
+    :param length:
+      Number of trits to squeeze, default to ``HASH_LENGTH``
     """
     #
     # Squeeze is kind of like the opposite of absorb; it copies trits
@@ -110,14 +137,39 @@ class Curl(object):
     # can simplify the implementation somewhat.
     #
 
+    # Ensure length can be mod by HASH_LENGTH
+    if length % HASH_LENGTH != 0:
+      raise with_context(
+        exc = ValueError('Invalid length passed to ``sequeeze`.'),
+        context = {
+          'trits': trits,
+          'offset': offset,
+          'length': length,
+        })
+
     # Ensure that ``trits`` can hold at least one hash worth of trits.
-    trits.extend([0] * max(0, HASH_LENGTH - len(trits)))
+    trits.extend([0] * max(0, length - len(trits)))
 
-    # Copy exactly one hash.
-    trits[0:HASH_LENGTH] = self._state[0:HASH_LENGTH]
+    # Check trits with offset can handle hash length
+    if len(trits) - offset < HASH_LENGTH:
+      raise with_context(
+        exc = ValueError('Invalid offset passed to ``squeeze``.'),
+        context = {
+          'trits': trits,
+          'offset': offset,
+          'length': length
+        },
+      )
 
-    # One hash worth of trits copied; now transform.
-    self._transform()
+    while length >= HASH_LENGTH:
+      # Copy exactly one hash.
+      trits[offset:offset + HASH_LENGTH] = self._state[0:HASH_LENGTH]
+
+      # One hash worth of trits copied; now transform.
+      self._transform()
+
+      offset += HASH_LENGTH
+      length -= HASH_LENGTH
 
   def _transform(self):
     # type: () -> None

--- a/iota/filters.py
+++ b/iota/filters.py
@@ -45,6 +45,11 @@ class NodeUri(f.BaseFilter):
   """
   Validates a string as a node URI.
   """
+  SCHEMES = {'tcp', 'udp'}
+  """
+  Allowed schemes for node URIs.
+  """
+
   CODE_NOT_NODE_URI = 'not_node_uri'
 
   templates = {
@@ -59,7 +64,7 @@ class NodeUri(f.BaseFilter):
 
     parsed = compat.urllib_parse.urlparse(value)
 
-    if parsed.scheme != 'udp':
+    if parsed.scheme not in self.SCHEMES:
       return self._invalid_value(value, self.CODE_NOT_NODE_URI)
 
     return value
@@ -148,14 +153,14 @@ class AddressNoChecksum(Trytes):
   """
   Validates a sequence as an Address then chops off the checksum if it exists
   """
-  ADDRESS_BAD_CHECKSUM   = 'address_bad_checksum'
+  ADDRESS_BAD_CHECKSUM = 'address_bad_checksum'
 
   templates = {
-    ADDRESS_BAD_CHECKSUM: 'Checksum is {supplied_checksum}, should be {expected_checksum}?',
+    ADDRESS_BAD_CHECKSUM:
+      'Checksum is {supplied_checksum}, should be {expected_checksum}?',
   }
 
   def __init__(self):
-    # type: (type) -> None
     super(AddressNoChecksum, self).__init__(result_type=Address)
 
   def _apply(self, value):
@@ -180,4 +185,5 @@ class AddressNoChecksum(Trytes):
           'expected_checksum': value.with_valid_checksum().checksum,
         },
       )
+
     return Address(value.address)

--- a/iota/transaction/base.py
+++ b/iota/transaction/base.py
@@ -9,8 +9,8 @@ from typing import Iterable, Iterator, List, MutableSequence, \
 from iota.codecs import TrytesDecodeError
 from iota.crypto import Curl, HASH_LENGTH
 from iota.json import JsonSerializable
-from iota.transaction.types import BundleHash, Fragment, Nonce, TransactionHash, \
-  TransactionTrytes
+from iota.transaction.types import BundleHash, Fragment, Nonce, \
+  TransactionHash, TransactionTrytes
 from iota.trits import int_from_trits, trits_from_int
 from iota.types import Address, Tag, TryteString, TrytesCompatible
 
@@ -485,7 +485,7 @@ class Bundle(JsonSerializable, Sequence[Transaction]):
 
       if message_trytes:
         try:
-          messages.append(message_trytes.as_string(decode_errors))
+          messages.append(message_trytes.decode(decode_errors))
         except (TrytesDecodeError, UnicodeDecodeError):
           if errors != 'drop':
             raise

--- a/iota/types.py
+++ b/iota/types.py
@@ -7,7 +7,8 @@ from itertools import chain
 from math import ceil
 from random import SystemRandom
 from typing import Any, AnyStr, Generator, Iterable, Iterator, List, \
-  MutableSequence, Optional, Text, Union
+  MutableSequence, Optional, Text, Type, TypeVar, Union
+from warnings import warn
 
 from six import PY2, binary_type, itervalues, python_2_unicode_compatible, \
   text_type
@@ -24,14 +25,16 @@ __all__ = [
   'AddressChecksum',
   'Hash',
   'Tag',
-  'TryteString',
   'TrytesCompatible',
+  'TryteString',
 ]
 
 
 # Custom types for type hints and docstrings.
 TrytesCompatible = Union[AnyStr, bytearray, 'TryteString']
 
+
+T = TypeVar('T', bound='TryteString')
 
 @python_2_unicode_compatible
 class TryteString(JsonSerializable):
@@ -67,7 +70,7 @@ class TryteString(JsonSerializable):
 
   @classmethod
   def from_bytes(cls, bytes_, codec=AsciiTrytesCodec.name, *args, **kwargs):
-    # type: (Union[binary_type, bytearray], Text, *Any, **Any) -> TryteString
+    # type: (Type[T], Union[binary_type, bytearray], Text, *Any, **Any) -> T
     """
     Creates a TryteString from a sequence of bytes.
 
@@ -75,11 +78,10 @@ class TryteString(JsonSerializable):
       Source bytes.
 
     :param codec:
-      Which codec to use:
+      Reserved for future use.
 
-        - 'trytes_binary': Converts each byte into a sequence of trits
-          with the same value (this is usually what you want).
-        - 'trytes_ascii': Uses the legacy ASCII codec.
+      See https://github.com/iotaledger/iota.lib.py/issues/62 for more
+      information.
 
     :param args:
       Additional positional arguments to pass to the initializer.
@@ -90,8 +92,8 @@ class TryteString(JsonSerializable):
     return cls(encode(bytes_, codec), *args, **kwargs)
 
   @classmethod
-  def from_string(cls, string, *args, **kwargs):
-    # type: (Text, *Any, **Any) -> TryteString
+  def from_unicode(cls, string, *args, **kwargs):
+    # type: (Type[T], Text, *Any, **Any) -> T
     """
     Creates a TryteString from a Unicode string.
 
@@ -112,8 +114,21 @@ class TryteString(JsonSerializable):
     )
 
   @classmethod
+  def from_string(cls, *args, **kwargs):
+    """
+    Deprecated; use :py:meth:`from_unicode` instead.
+
+    https://github.com/iotaledger/iota.lib.py/issues/90
+    """
+    warn(
+      message='`from_string()` is deprecated; use `from_unicode()` instead.',
+      category=DeprecationWarning,
+    )
+    return cls.from_unicode(*args, **kwargs)
+
+  @classmethod
   def from_trytes(cls, trytes, *args, **kwargs):
-    # type: (Iterable[Iterable[int]], *Any, **Any) -> TryteString
+    # type: (Type[T], Iterable[Iterable[int]], *Any, **Any) -> T
     """
     Creates a TryteString from a sequence of trytes.
 
@@ -145,7 +160,7 @@ class TryteString(JsonSerializable):
 
   @classmethod
   def from_trits(cls, trits, *args, **kwargs):
-    # type: (Iterable[int], *Any, **Any) -> TryteString
+    # type: (Type[T], Iterable[int], *Any, **Any) -> T
     """
     Creates a TryteString from a sequence of trits.
 
@@ -234,7 +249,7 @@ class TryteString(JsonSerializable):
 
     else:
       if isinstance(trytes, text_type):
-        trytes = trytes.encode('ascii')
+        trytes = encode(trytes, 'ascii')
 
       if not isinstance(trytes, bytearray):
         trytes = bytearray(trytes)
@@ -279,8 +294,8 @@ class TryteString(JsonSerializable):
     only returns an ASCII representation of the trytes themselves!
 
     If you want to...
-    - ... decode trytes into bytes: use :py:meth:`as_bytes`.
-    - ... decode trytes into Unicode: use :py:meth:`as_string`.
+    - ... encode trytes into bytes: use :py:meth:`encode`.
+    - ... decode trytes into Unicode: use :py:meth:`decode`.
     """
     return binary_type(self._trytes)
 
@@ -444,10 +459,11 @@ class TryteString(JsonSerializable):
     """
     return ChunkIterator(self, chunk_size)
 
-  def as_bytes(self, errors='strict', codec=AsciiTrytesCodec.name):
+  def encode(self, errors='strict', codec=AsciiTrytesCodec.name):
     # type: (Text, Text) -> binary_type
     """
-    Converts the TryteString into a byte string.
+    Encodes the TryteString into a lower-level primitive (usually
+    bytes).
 
     :param errors:
       How to handle trytes that can't be converted:
@@ -456,24 +472,41 @@ class TryteString(JsonSerializable):
         - 'ignore':   omit the tryte from the result.
 
     :param codec:
-      Which codec to use:
+      Reserved for future use.
 
-      - 'trytes_binary': Converts each sequence of 5 trits into a byte
-        with the same value (this is usually what you want).
-      - 'trytes_ascii': Uses the legacy ASCII codec.
+      See https://github.com/iotaledger/iota.lib.py/issues/62 for more
+      information.
 
     :raise:
       - :py:class:`iota.codecs.TrytesDecodeError` if the trytes cannot
         be decoded into bytes.
     """
+    # Converting ASCII-encoded trytes into bytes is considered to be a
+    # *decode* operation according to :py:class:`AsciiTrytesCodec`.
+    # Once we add more codecs, we may need to revisit this.
+    # See https://github.com/iotaledger/iota.lib.py/issues/62 for more
+    # information.
+    #
     # In Python 2, :py:func:`decode` does not accept keyword arguments.
     return decode(self._trytes, codec, errors)
 
-  def as_string(self, errors='strict', strip_padding=True):
+  def as_bytes(self, *args, **kwargs):
+    """
+    Deprecated; use :py:meth:`encode` instead.
+
+    https://github.com/iotaledger/iota.lib.py/issues/90
+    """
+    warn(
+      category=DeprecationWarning,
+      message='`as_bytes()` is deprecated; use `encode()` instead.',
+    )
+    return self.encode(*args, **kwargs)
+
+  def decode(self, errors='strict', strip_padding=True):
     # type: (Text, bool) -> Text
     """
-    Attempts to interpret the TryteString as a UTF-8 encoded Unicode
-    string.
+    Decodes the TryteString into a higher-level abstraction (usually
+    Unicode characters).
 
     :param errors:
       How to handle trytes that can't be converted, or bytes that can't
@@ -499,6 +532,18 @@ class TryteString(JsonSerializable):
       trytes += b'9' * (len(trytes) % 2)
 
     return decode(trytes, AsciiTrytesCodec.name, errors).decode('utf-8', errors)
+
+  def as_string(self, *args, **kwargs):
+    """
+    Deprecated; use :py:meth:`decode` instead.
+
+    https://github.com/iotaledger/iota.lib.py/issues/90
+    """
+    warn(
+      category=DeprecationWarning,
+      message='`as_string()` is deprecated; use `decode()` instead.',
+    )
+    return self.decode(*args, **kwargs)
 
   def as_json_compatible(self):
     # type: () -> Text
@@ -757,7 +802,7 @@ class Address(TryteString):
     )
 
   def _generate_checksum(self):
-    # type: () -> TryteString
+    # type: () -> AddressChecksum
     """
     Generates the correct checksum for this address.
     """
@@ -769,7 +814,7 @@ class Address(TryteString):
 
     checksum_length = AddressChecksum.LEN * TRITS_PER_TRYTE
 
-    return TryteString.from_trits(checksum_trits[-checksum_length:])
+    return AddressChecksum.from_trits(checksum_trits[-checksum_length:])
 
 
 class AddressChecksum(TryteString):

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
   # http://python-packaging.readthedocs.io/en/latest/command-line-scripts.html#the-console-scripts-entry-point
   entry_points = {
     'console_scripts': [
-      'iota-cli=iota.bin.repl:main',
+      'pyota-cli=iota.bin.repl:main',
     ],
   },
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
   name        = 'PyOTA',
   description = 'IOTA API library for Python',
   url         = 'https://github.com/iotaledger/iota.lib.py',
-  version     = '2.0.3',
+  version     = '2.0.4',
 
   long_description = long_description,
 

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
   extras_require = {
     'ccurl': ['pyota-ccurl'],
     'docs-builder': ['sphinx', 'sphinx_rtd_theme'],
+    'test-runner': ['detox'],
   },
 
   test_suite    = 'test',

--- a/test/adapter_test.py
+++ b/test/adapter_test.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, \
   unicode_literals
 
 import json
+import socket
 from typing import Text
 from unittest import TestCase
 
@@ -313,6 +314,65 @@ class HttpAdapterTestCase(TestCase):
         response = invalid_response,
       ),
     )
+
+  @mock.patch('iota.adapter.request')
+  def test_default_timeout(self, request_mock):
+    # create dummy response
+    request_mock.return_value = mock.Mock(text='{ "dummy": "payload"}', status_code=200)
+
+    # create adapter
+    mock_payload = {'dummy': 'payload'}
+    adapter = HttpAdapter('http://localhost:14265')
+
+    # test with default timeout
+    adapter.send_request(payload=mock_payload)
+    _, kwargs = request_mock.call_args
+    self.assertEqual(kwargs['timeout'], socket.getdefaulttimeout())
+
+  @mock.patch('iota.adapter.request')
+  def test_instance_attribute_timeout(self, request_mock):
+    # create dummy response
+    request_mock.return_value = mock.Mock(text='{ "dummy": "payload"}', status_code=200)
+
+    # create adapter
+    mock_payload = {'dummy': 'payload'}
+    adapter = HttpAdapter('http://localhost:14265')
+
+    # test with explicit attribute
+    adapter.timeout = 77
+    adapter.send_request(payload=mock_payload)
+    _, kwargs = request_mock.call_args
+    self.assertEqual(kwargs['timeout'], 77)
+
+  @mock.patch('iota.adapter.request')
+  def test_argument_overriding_attribute_timeout(self, request_mock):
+    # create dummy response
+    request_mock.return_value = mock.Mock(text='{ "dummy": "payload"}', status_code=200)
+
+    # create adapter
+    mock_payload = {'dummy': 'payload'}
+    adapter = HttpAdapter('http://localhost:14265')
+
+    # test with timeout in kwargs
+    adapter.timeout = 77
+    adapter.send_request(payload=mock_payload, timeout=88)
+    _, kwargs = request_mock.call_args
+    self.assertEqual(kwargs['timeout'], 88)
+
+  @mock.patch('iota.adapter.request')
+  def test_argument_overriding_init_timeout(self, request_mock):
+    # create dummy response
+    request_mock.return_value = mock.Mock(text='{ "dummy": "payload"}', status_code=200)
+
+    # create adapter
+    mock_payload = {'dummy': 'payload'}
+    adapter = HttpAdapter('http://localhost:14265')
+
+    # test with timeout at adapter creation
+    adapter = HttpAdapter('http://localhost:14265', timeout=99)
+    adapter.send_request(payload=mock_payload)
+    _, kwargs = request_mock.call_args
+    self.assertEqual(kwargs['timeout'], 99)
 
   # noinspection SpellCheckingInspection
   @staticmethod

--- a/test/commands/core/get_tips_test.py
+++ b/test/commands/core/get_tips_test.py
@@ -6,9 +6,11 @@ from unittest import TestCase
 
 import filters as f
 from filters.test import BaseFilterTestCase
+
 from iota import Address, Iota
 from iota.adapter import MockAdapter
 from iota.commands.core.get_tips import GetTipsCommand
+from iota.transaction.types import TransactionHash
 
 
 class GetTipsRequestFilterTestCase(BaseFilterTestCase):
@@ -122,4 +124,29 @@ class GetTipsCommandTestCase(TestCase):
     self.assertIsInstance(
       Iota(self.adapter).getTips,
       GetTipsCommand,
+    )
+
+  def test_type_coercion(self):
+    """
+    The result is coerced to the proper type.
+
+    https://github.com/iotaledger/iota.lib.py/issues/130
+    """
+    # noinspection SpellCheckingInspection
+    self.adapter.seed_response('getTips', {
+      'duration': 42,
+      'hashes': [
+        'TESTVALUE9DONTUSEINPRODUCTION99999ANSVWB'
+        'CZ9ABZYUK9YYXFRLROGMCMQHRARDQPNMHHZSZ9999',
+
+        'TESTVALUE9DONTUSEINPRODUCTION99999HCZURL'
+        'NFWEDRFCYHWTYGUEMJLJ9ZIJTFASAVSEAZJGA9999',
+      ],
+    })
+
+    gt_response = Iota(self.adapter).get_tips()
+
+    self.assertEqual(
+      list(map(type, gt_response['hashes'])),
+      [TransactionHash] * 2,
     )

--- a/test/commands/extended/helpers_test.py
+++ b/test/commands/extended/helpers_test.py
@@ -1,0 +1,45 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, \
+  unicode_literals
+
+from unittest import TestCase
+
+from iota import Iota, TransactionHash
+from iota.adapter import MockAdapter
+
+
+class HelpersTestCase(TestCase):
+  def setUp(self):
+    super(HelpersTestCase, self).setUp()
+
+    self.api = api = Iota('mock://')
+    self.api.adapter = MockAdapter()
+
+    # noinspection SpellCheckingInspection
+    self.transaction = (
+      'TESTVALUE9DONTUSEINPRODUCTION99999KPZOTR'
+      'VDB9GZDJGZSSDCBIX9QOK9PAV9RMDBGDXLDTIZTWQ'
+    )
+
+  def test_positive_is_promotable(self):
+    """
+    Transaction is promotable
+    """
+
+    self.api.adapter.seed_response('checkConsistency', {
+      'state': True,
+    })
+
+    self.assertTrue(self.api.helpers.is_promotable(tail=self.transaction))
+
+  def test_negative_is_promotable(self):
+    """
+    Transaction is not promotable
+    """
+
+    self.api.adapter.seed_response('checkConsistency', {
+      'state': False,
+      'info': 'Inconsistent state',
+    })
+
+    self.assertFalse(self.api.helpers.is_promotable(tail=self.transaction))

--- a/test/commands/extended/is_reattachable_test.py
+++ b/test/commands/extended/is_reattachable_test.py
@@ -1,0 +1,206 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, \
+  unicode_literals
+
+from unittest import TestCase
+
+import filters as f
+from filters.test import BaseFilterTestCase
+from six import text_type
+
+from iota import Address, Iota
+from iota.adapter import MockAdapter
+from iota.commands.extended.is_reattachable import IsReattachableCommand
+
+
+class IsReattachableRequestFilterTestCase(BaseFilterTestCase):
+  filter_type = IsReattachableCommand(MockAdapter()).get_request_filter
+  skip_value_check = True
+
+  # noinspection SpellCheckingInspection
+  def setUp(self):
+    super(IsReattachableRequestFilterTestCase, self).setUp()
+
+    # Define a few valid values that we can reuse across tests.
+    self.address_1 = (
+      'TESTVALUE9DONTUSEINPRODUCTION99999EKJZZT'
+      'SOGJOUNVEWLDPKGTGAOIZIPMGBLHC9LMQNHLGXGYX'
+    )
+
+    self.address_2 = (
+      'TESTVALUE9DONTUSEINPRODUCTION99999FDCDTZ'
+      'ZWLL9MYGUTLSYVSIFJ9NGALTRMCQVIIOVEQOITYTE'
+    )
+
+  def test_pass_happy_path(self):
+    """
+    Filter for list of valid string addresses
+    """
+
+    request = {
+      # Raw trytes are extracted to match the IRI's JSON protocol.
+      'addresses': [
+        self.address_1,
+        Address(self.address_2)
+      ],
+    }
+
+    filter_ = self._filter(request)
+
+    self.assertFilterPasses(filter_)
+
+    self.assertDictEqual(
+      filter_.cleaned_data,
+      {
+        'addresses': [
+          text_type(Address(self.address_1)),
+          text_type(Address(self.address_2))
+        ],
+      },
+    )
+
+  def test_pass_compatible_types(self):
+    """
+    The incoming request contains values that can be converted to the
+    expected types.
+    """
+    request = {
+      'addresses': [
+        Address(self.address_1),
+        bytearray(self.address_2.encode('ascii')),
+      ],
+    }
+
+    filter_ = self._filter(request)
+
+    self.assertFilterPasses(filter_)
+    self.assertDictEqual(
+      filter_.cleaned_data,
+      {
+        'addresses': [self.address_1, self.address_2],
+      },
+    )
+
+  def test_pass_incompatible_types(self):
+    """
+    The incoming request contains values that can NOT be converted to the
+    expected types.
+    """
+    request = {
+      'addresses': [
+        1234234,
+        False
+      ],
+    }
+
+    self.assertFilterErrors(
+      request,
+      {
+        'addresses.0': [f.Type.CODE_WRONG_TYPE],
+        'addresses.1': [f.Type.CODE_WRONG_TYPE]
+      },
+    )
+
+  def test_fail_empty(self):
+    """
+    The incoming request is empty.
+    """
+    self.assertFilterErrors(
+      {},
+      {
+        'addresses': [f.FilterMapper.CODE_MISSING_KEY],
+      },
+    )
+
+  def test_fail_single_address(self):
+    """
+    The incoming request contains a single address
+    """
+    request = {
+      'addresses': Address(self.address_1)
+    }
+
+    self.assertFilterErrors(
+      request,
+      {
+        'addresses': [f.Type.CODE_WRONG_TYPE],
+      }
+    )
+
+
+# noinspection SpellCheckingInspection
+class IsReattachableResponseFilterTestCase(BaseFilterTestCase):
+  filter_type = IsReattachableCommand(MockAdapter()).get_response_filter
+  skip_value_check = True
+
+  # noinspection SpellCheckingInspection
+  def setUp(self):
+    super(IsReattachableResponseFilterTestCase, self).setUp()
+
+    # Define a few valid values that we can reuse across tests.
+    self.addresses_1 = (
+      'TESTVALUE9DONTUSEINPRODUCTION99999EKJZZT'
+      'SOGJOUNVEWLDPKGTGAOIZIPMGBLHC9LMQNHLGXGYX'
+    )
+
+  def test_pass_happy_path(self):
+    """
+    Typical ``IsReattachable`` request.
+    """
+    response = {
+      'reattachable': [True, False]
+    }
+
+    filter_ = self._filter(response)
+
+    self.assertFilterPasses(filter_)
+    self.assertDictEqual(filter_.cleaned_data, response)
+
+  def test_fail_empty(self):
+    """
+    The incoming response is empty.
+    """
+    self.assertFilterErrors(
+      {},
+      {
+        'reattachable': [f.Required.CODE_EMPTY],
+      },
+    )
+
+  def test_pass_incompatible_types(self):
+    """
+    The response contains values that can NOT be converted to the
+    expected types.
+    """
+    request = {
+      'reattachable': [
+        1234234,
+        b'',
+        'test'
+      ],
+    }
+
+    self.assertFilterErrors(
+      request,
+      {
+        'reattachable.0': [f.Type.CODE_WRONG_TYPE],
+        'reattachable.1': [f.Type.CODE_WRONG_TYPE],
+        'reattachable.2': [f.Type.CODE_WRONG_TYPE]
+      },
+    )
+
+
+class IsReattachableCommandTestCase(TestCase):
+  def setUp(self):
+    super(IsReattachableCommandTestCase, self).setUp()
+
+    self.adapter = MockAdapter()
+
+  def test_wireup(self):
+    """
+    Verify that the command is wired up correctly.
+    """
+    self.assertIsInstance(
+      Iota(self.adapter).isReattachable,
+      IsReattachableCommand,
+    )

--- a/test/commands/extended/prepare_transfer_test.py
+++ b/test/commands/extended/prepare_transfer_test.py
@@ -1132,7 +1132,7 @@ class PrepareTransferCommandTestCase(TestCase):
               'VNDMLXPT9HMVAOWUUZMLSJZFWGKDVGXPSQAWAEBJN'
             ),
 
-          message = TryteString.from_string('สวัสดีชาวโลก!'),
+          message = TryteString.from_unicode('สวัสดีชาวโลก!'),
           tag     = Tag('PYOTA9UNIT9TESTS9'),
           value   = 0,
         ),
@@ -1168,7 +1168,7 @@ class PrepareTransferCommandTestCase(TestCase):
               ),
 
             message =
-              TryteString.from_string(
+              TryteString.from_unicode(
                 'Вы не можете справиться правду! Сын, мы живем в мире, который '
                 'имеет стены. И эти стены должны быть охраняют люди с оружием. '
                 'Кто будет это делать? Вы? Вы, лейтенант Weinberg? У меня есть '

--- a/test/commands/extended/promote_transaction_test.py
+++ b/test/commands/extended/promote_transaction_test.py
@@ -1,0 +1,371 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, \
+  unicode_literals
+
+from unittest import TestCase
+
+import filters as f
+from filters.test import BaseFilterTestCase
+from six import binary_type
+
+from iota import Bundle, Iota, TransactionHash, TransactionTrytes, BadApiResponse
+from iota.adapter import MockAdapter
+from iota.commands.extended.promote_transaction import PromoteTransactionCommand
+from iota.filters import Trytes
+from test import mock
+
+
+class PromoteTransactionRequestFilterTestCase(BaseFilterTestCase):
+  filter_type = PromoteTransactionCommand(MockAdapter()).get_request_filter
+  skip_value_check = True
+
+  # noinspection SpellCheckingInspection
+  def setUp(self):
+    super(PromoteTransactionRequestFilterTestCase, self).setUp()
+
+    self.trytes1 = (
+      b'TESTVALUEONE9DONTUSEINPRODUCTION99999DAU'
+      b'9WFSFWBSFT9QATCXFIIKDVFLHIIJGGFCDYENBEDCF'
+    )
+
+  def test_pass_happy_path(self):
+    """
+    Request is valid.
+    """
+    request = {
+      'depth':              100,
+      'minWeightMagnitude': 18,
+      'transaction':        TransactionHash(self.trytes1),
+    }
+
+    filter_ = self._filter(request)
+
+    self.assertFilterPasses(filter_)
+    self.assertDictEqual(filter_.cleaned_data, request)
+
+  def test_pass_compatible_types(self):
+    """
+    Request contains values that can be converted to the expected
+    types.
+    """
+    filter_ = self._filter({
+      # This can be any TrytesCompatible value.
+      'transaction': binary_type(self.trytes1),
+
+      # These values must still be ints, however.
+      'depth':              100,
+      'minWeightMagnitude': 18,
+    })
+
+    self.assertFilterPasses(filter_)
+    self.assertDictEqual(
+      filter_.cleaned_data,
+
+      {
+        'depth':              100,
+        'minWeightMagnitude': 18,
+        'transaction':        TransactionHash(self.trytes1),
+      },
+    )
+
+  def test_fail_empty(self):
+    """
+    Request is empty.
+    """
+    self.assertFilterErrors(
+      {},
+
+      {
+        'depth':              [f.FilterMapper.CODE_MISSING_KEY],
+        'minWeightMagnitude': [f.FilterMapper.CODE_MISSING_KEY],
+        'transaction':        [f.FilterMapper.CODE_MISSING_KEY],
+      },
+    )
+
+  def test_fail_unexpected_parameters(self):
+    """
+    Request contains unexpected parameters.
+    """
+    self.assertFilterErrors(
+      {
+        'depth':              100,
+        'minWeightMagnitude': 18,
+        'transaction':        TransactionHash(self.trytes1),
+
+        # That's a real nasty habit you got there.
+        'foo': 'bar',
+      },
+
+      {
+        'foo': [f.FilterMapper.CODE_EXTRA_KEY],
+      },
+    )
+
+  def test_fail_transaction_null(self):
+    """
+    ``transaction`` is null.
+    """
+    self.assertFilterErrors(
+      {
+        'transaction': None,
+
+        'depth':              100,
+        'minWeightMagnitude': 18,
+      },
+
+      {
+        'transaction': [f.Required.CODE_EMPTY],
+      },
+    )
+
+  def test_fail_transaction_wrong_type(self):
+    """
+    ``transaction`` is not a TrytesCompatible value.
+    """
+    self.assertFilterErrors(
+      {
+        'transaction': 42,
+
+        'depth':              100,
+        'minWeightMagnitude': 18,
+      },
+
+      {
+        'transaction': [f.Type.CODE_WRONG_TYPE],
+      },
+    )
+
+  def test_fail_transaction_not_trytes(self):
+    """
+    ``transaction`` contains invalid characters.
+    """
+    self.assertFilterErrors(
+      {
+        'transaction': b'not valid; must contain only uppercase and "9"',
+
+        'depth':              100,
+        'minWeightMagnitude': 18,
+      },
+
+      {
+        'transaction': [Trytes.CODE_NOT_TRYTES],
+      },
+    )
+
+  def test_fail_depth_null(self):
+    """
+    ``depth`` is null.
+    """
+    self.assertFilterErrors(
+      {
+        'depth': None,
+
+        'minWeightMagnitude': 18,
+        'transaction':        TransactionHash(self.trytes1),
+      },
+
+      {
+        'depth': [f.Required.CODE_EMPTY],
+      },
+    )
+
+  def test_fail_depth_string(self):
+    """
+    ``depth`` is a string.
+    """
+    self.assertFilterErrors(
+      {
+        # Too ambiguous; it's gotta be an int.
+        'depth': '4',
+
+        'minWeightMagnitude': 18,
+        'transaction':        TransactionHash(self.trytes1),
+      },
+
+      {
+        'depth': [f.Type.CODE_WRONG_TYPE],
+      },
+    )
+
+  def test_fail_depth_float(self):
+    """
+    ``depth`` is a float.
+    """
+    self.assertFilterErrors(
+      {
+        # Even with an empty fpart, float value is not valid.
+        'depth': 8.0,
+
+        'minWeightMagnitude': 18,
+        'transaction':        TransactionHash(self.trytes1),
+      },
+
+      {
+        'depth': [f.Type.CODE_WRONG_TYPE],
+      },
+    )
+
+  def test_fail_depth_too_small(self):
+    """
+    ``depth`` is < 1.
+    """
+    self.assertFilterErrors(
+      {
+        'depth': 0,
+
+        'minWeightMagnitude': 18,
+        'transaction':        TransactionHash(self.trytes1),
+      },
+
+      {
+        'depth': [f.Min.CODE_TOO_SMALL],
+      },
+    )
+
+  def test_fail_min_weight_magnitude_null(self):
+    """
+    ``minWeightMagnitude`` is null.
+    """
+    self.assertFilterErrors(
+      {
+        'minWeightMagnitude': None,
+
+        'depth':        100,
+        'transaction':  TransactionHash(self.trytes1),
+      },
+
+      {
+        'minWeightMagnitude': [f.Required.CODE_EMPTY],
+      },
+    )
+
+  def test_fail_min_weight_magnitude_string(self):
+    """
+    ``minWeightMagnitude`` is a string.
+    """
+    self.assertFilterErrors(
+      {
+        # It's gotta be an int!
+        'minWeightMagnitude': '18',
+
+        'depth':        100,
+        'transaction':  TransactionHash(self.trytes1),
+      },
+
+      {
+        'minWeightMagnitude': [f.Type.CODE_WRONG_TYPE],
+      },
+    )
+
+  def test_fail_min_weight_magnitude_float(self):
+    """
+    ``minWeightMagnitude`` is a float.
+    """
+    self.assertFilterErrors(
+      {
+        # Even with an empty fpart, float values are not valid.
+        'minWeightMagnitude': 18.0,
+
+        'depth':        100,
+        'transaction':  TransactionHash(self.trytes1),
+      },
+
+      {
+        'minWeightMagnitude': [f.Type.CODE_WRONG_TYPE],
+      },
+    )
+
+  def test_fail_min_weight_magnitude_too_small(self):
+    """
+    ``minWeightMagnitude`` is < 1.
+    """
+    self.assertFilterErrors(
+      {
+        'minWeightMagnitude': 0,
+
+        'depth':        100,
+        'transaction':  TransactionHash(self.trytes1),
+      },
+
+      {
+        'minWeightMagnitude': [f.Min.CODE_TOO_SMALL],
+      },
+    )
+
+
+class PromoteTransactionCommandTestCase(TestCase):
+  def setUp(self):
+    super(PromoteTransactionCommandTestCase, self).setUp()
+
+    self.adapter = MockAdapter()
+    self.command = PromoteTransactionCommand(self.adapter)
+
+    self.trytes1 = b'RBTC9D9DCDQAEASBYBCCKBFA'
+    self.trytes2 =\
+      b'CCPCBDVC9DTCEAKDXC9D9DEARCWCPCBDVCTCEAHDWCTCEAKDCDFD9DSCSA'
+
+    self.hash1 = TransactionHash(
+      b'TESTVALUE9DONTUSEINPRODUCTION99999TBPDM9'
+      b'ADFAWCKCSFUALFGETFIFG9UHIEFE9AYESEHDUBDDF'
+    )
+
+  def test_wireup(self):
+    """
+    Verifies that the command is wired-up correctly.
+    """
+    self.assertIsInstance(
+      Iota(self.adapter).promoteTransaction,
+      PromoteTransactionCommand,
+    )
+
+  def test_happy_path(self):
+    """
+    Successfully promoting a bundle.
+    """
+
+    self.adapter.seed_response('checkConsistency', {
+      'state': True,
+    })
+
+    result_bundle = Bundle.from_tryte_strings([
+      TransactionTrytes(self.trytes1),
+      TransactionTrytes(self.trytes2),
+    ])
+    mock_send_transfer = mock.Mock(return_value={
+      'bundle': result_bundle,
+    })
+
+    with mock.patch(
+        'iota.commands.extended.send_transfer.SendTransferCommand._execute',
+        mock_send_transfer,
+    ):
+
+      response = self.command(
+        transaction=self.hash1,
+        depth=3,
+        minWeightMagnitude=16,
+      )
+
+    self.assertDictEqual(
+      response,
+
+      {
+        'bundle': result_bundle,
+      }
+    )
+
+  def test_not_promotable(self):
+    """
+    Bundle isn't promotable.
+    """
+
+    self.adapter.seed_response('checkConsistency', {
+      'state': False,
+    })
+
+    with self.assertRaises(BadApiResponse):
+      response = self.command(
+        transaction=self.hash1,
+        depth=3,
+        minWeightMagnitude=16,
+      )

--- a/test/commands/extended/send_trytes_test.py
+++ b/test/commands/extended/send_trytes_test.py
@@ -8,7 +8,7 @@ import filters as f
 from filters.test import BaseFilterTestCase
 from six import binary_type, text_type
 
-from iota import Iota, TransactionTrytes, TryteString
+from iota import Iota, TransactionTrytes, TryteString, TransactionHash
 from iota.adapter import MockAdapter
 from iota.commands.extended.send_trytes import SendTrytesCommand
 from iota.filters import Trytes
@@ -40,6 +40,8 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
         TransactionTrytes(self.trytes1),
         TransactionTrytes(self.trytes2),
       ],
+
+      'reference': TransactionHash(self.trytes1),
     }
 
     filter_ = self._filter(request)
@@ -58,6 +60,7 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
         binary_type(self.trytes1),
         bytearray(self.trytes2),
       ],
+      'reference': binary_type(self.trytes2),
 
       # These still have to be ints, however.
       'depth':              100,
@@ -76,6 +79,7 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
           TransactionTrytes(self.trytes1),
           TransactionTrytes(self.trytes2),
         ],
+        'reference': TransactionHash(self.trytes2)
       },
     )
 

--- a/test/crypto/pycurl_test.py
+++ b/test/crypto/pycurl_test.py
@@ -8,158 +8,200 @@ from iota import TryteString
 from iota.crypto import Curl
 
 
-class TestCurl(TestCase):
+class CurlTestCase(TestCase):
+  """
+  This is the test case for CURL-P hash function used in IOTA.
+
+  Note that this test case covers :py:data:`iota.crypto.Curl`, **not**
+  :py:class:`iota.crypto.pycurl.Curl`.
+
+  This is intentional; it enables us to run unit tests for the C
+  extension with the same code.
+
+  See https://github.com/todofixthis/pyota-ccurl/ for more information.
+  """
+
+  def test_happy_path(self):
     """
-    This is the test case for CURL-P hash function used in IOTA
+    Typical use case.
     """
-    def test_correct_first(self):
-        """Test the inp tryte string will get the correct output"""
-        inp = (
-          'EMIDYNHBWMBCXVDEFOFWINXTERALUKYYPPHKP9JJ'
-          'FGJEIUY9MUDVNFZHMMWZUYUSWAIOWEVTHNWMHANBH'
-        )
+    # noinspection SpellCheckingInspection
+    input_ = (
+      'EMIDYNHBWMBCXVDEFOFWINXTERALUKYYPPHKP9JJ'
+      'FGJEIUY9MUDVNFZHMMWZUYUSWAIOWEVTHNWMHANBH'
+    )
 
-        trits = TryteString(inp).as_trits()
+    trits = TryteString(input_).as_trits()
 
-        curl = Curl()
-        curl.absorb(trits)
-        trits_out = []
-        curl.squeeze(trits_out)
+    curl = Curl()
+    curl.absorb(trits)
+    trits_out = []
+    curl.squeeze(trits_out)
 
-        trits_out = TryteString.from_trits(trits_out)
+    trits_out = TryteString.from_trits(trits_out)
 
-        self.assertEqual(
-            trits_out,
-            'AQBOPUMJMGVHFOXSMUAGZNACKUTISDPBSILMRAGIG'
-            'RXXS9JJTLIKZUW9BCJWKSTFBDSBLNVEEGVGAMSSM')
+    # noinspection SpellCheckingInspection
+    self.assertEqual(
+      trits_out,
 
-    def test_input_length_greater_than_243(self):
-        """Test input trytes length greater than hash length should work"""
-        inp = (
-          'G9JYBOMPUXHYHKSNRNMMSSZCSHOFYOYNZRSZMAAYWDYEIMVVOGKPJB'
-          'VBM9TDPULSFUNMTVXRKFIDOHUXXVYDLFSZYZTWQYTE9SPYYWYTXJYQ'
-          '9IFGYOLZXWZBKWZN9QOOTBQMWMUBLEWUEEASRHRTNIQWJQNDWRYLCA'
-        )
+      'AQBOPUMJMGVHFOXSMUAGZNACKUTISDPBSILMRAGI'
+      'GRXXS9JJTLIKZUW9BCJWKSTFBDSBLNVEEGVGAMSSM',
+    )
 
-        trits = TryteString(inp).as_trits()
+  def test_length_greater_than_243(self):
+    """
+    The input is longer than 1 hash.
+    """
+    # noinspection SpellCheckingInspection
+    input_ = (
+      'G9JYBOMPUXHYHKSNRNMMSSZCSHOFYOYNZRSZMAAYWDYEIMVVOGKPJB'
+      'VBM9TDPULSFUNMTVXRKFIDOHUXXVYDLFSZYZTWQYTE9SPYYWYTXJYQ'
+      '9IFGYOLZXWZBKWZN9QOOTBQMWMUBLEWUEEASRHRTNIQWJQNDWRYLCA'
+    )
 
-        curl = Curl()
-        curl.absorb(trits)
-        trits_out = []
-        curl.squeeze(trits_out)
+    trits = TryteString(input_).as_trits()
 
-        trits_out = TryteString.from_trits(trits_out)
+    curl = Curl()
+    curl.absorb(trits)
+    trits_out = []
+    curl.squeeze(trits_out)
 
-        self.assertEqual(
-            trits_out,
-            'RWCBOLRFANOAYQWXXTFQJYQFAUTEEBSZWTIRSSDR'
-            'EYGCNFRLHQVDZXYXSJKCQFQLJMMRHYAZKRRLQZDKR')
+    trits_out = TryteString.from_trits(trits_out)
 
-    def test_input_without_offset(self):
-        """Test input without offset should work"""
-        inp = (
-          'G9JYBOMPUXHYHKSNRNMMSSZCSHOFYOYNZRSZMAAYWDYEIMVVOGKPJB'
-          'VBM9TDPULSFUNMTVXRKFIDOHUXXVYDLFSZYZTWQYTE9SPYYWYTXJYQ'
-          '9IFGYOLZXWZBKWZN9QOOTBQMWMUBLEWUEEASRHRTNIQWJQNDWRYLCA'
-        )
+    # noinspection SpellCheckingInspection
+    self.assertEqual(
+      trits_out,
 
-        trits = TryteString(inp).as_trits()
+      'RWCBOLRFANOAYQWXXTFQJYQFAUTEEBSZWTIRSSDR'
+      'EYGCNFRLHQVDZXYXSJKCQFQLJMMRHYAZKRRLQZDKR',
+    )
 
-        curl = Curl()
-        curl.absorb(trits, 0, length=486)
-        curl.absorb(trits, 0, length=243)
-        trits_out = []
-        curl.squeeze(trits_out)
+  def test_length(self):
+    """
+    Specifying different values for the ``length`` argument.
+    """
+    # noinspection SpellCheckingInspection
+    input_ = (
+      'G9JYBOMPUXHYHKSNRNMMSSZCSHOFYOYNZRSZMAAYWDYEIMVVOGKPJB'
+      'VBM9TDPULSFUNMTVXRKFIDOHUXXVYDLFSZYZTWQYTE9SPYYWYTXJYQ'
+      '9IFGYOLZXWZBKWZN9QOOTBQMWMUBLEWUEEASRHRTNIQWJQNDWRYLCA'
+    )
 
-        trits_out = TryteString.from_trits(trits_out)
+    trits = TryteString(input_).as_trits()
 
-        self.assertEqual(
-            trits_out,
-            'OTYHXEXJLCSMEY9LYCC9ASJXMORTLAYQEHRS9DAH'
-            '9NR9DXLXYDGOVOBEL9LWRITLWPHPYPZDKXVPAPKUA')
+    curl = Curl()
+    curl.absorb(trits, offset=0, length=486)
+    curl.absorb(trits, offset=0, length=243)
+    trits_out = []
+    curl.squeeze(trits_out)
 
-    def test_input_with_offset(self):
-        """Test input with offset should work"""
-        inp = (
-          'G9JYBOMPUXHYHKSNRNMMSSZCSHOFYOYNZRSZMAAYWDYEIMVVOGKPJB'
-          'VBM9TDPULSFUNMTVXRKFIDOHUXXVYDLFSZYZTWQYTE9SPYYWYTXJYQ'
-          '9IFGYOLZXWZBKWZN9QOOTBQMWMUBLEWUEEASRHRTNIQWJQNDWRYLCA'
-        )
+    trits_out = TryteString.from_trits(trits_out)
 
-        trits = TryteString(inp).as_trits()
+    # noinspection SpellCheckingInspection
+    self.assertEqual(
+      trits_out,
 
-        curl = Curl()
-        curl.absorb(trits, 243, length=486)
-        curl.absorb(trits, 0, length=243)
-        trits_out = []
-        curl.squeeze(trits_out)
+      'OTYHXEXJLCSMEY9LYCC9ASJXMORTLAYQEHRS9DAH'
+      '9NR9DXLXYDGOVOBEL9LWRITLWPHPYPZDKXVPAPKUA',
+    )
 
-        trits_out = TryteString.from_trits(trits_out)
+  def test_absorb_offset(self):
+    """
+    Passing an ``offset`` argument to :py:meth:`Curl.absorb`.
+    """
+    # noinspection SpellCheckingInspection
+    input_ = (
+      'G9JYBOMPUXHYHKSNRNMMSSZCSHOFYOYNZRSZMAAYWDYEIMVVOGKPJB'
+      'VBM9TDPULSFUNMTVXRKFIDOHUXXVYDLFSZYZTWQYTE9SPYYWYTXJYQ'
+      '9IFGYOLZXWZBKWZN9QOOTBQMWMUBLEWUEEASRHRTNIQWJQNDWRYLCA'
+    )
 
-        self.assertEqual(
-            trits_out,
-            'ZWNF9YOCAKC9CXQFYZDKXSSAZOCAZLEVEB9OZDJQG'
-            'WEULHUDY9RAWAT9GIUXTTUSYJEGNGQDVJCGTQLN9')
+    trits = TryteString(input_).as_trits()
 
-    def test_squeeze_with_offset(self):
-        """Test squeeze with offset, this only used in ISS
-        GitHub IRI ISS: https://github.com/iotaledger/iri/blob/dev/src/main/java/com/iota/iri/hash/ISS.java#L83
-        """
-        inp = (
-            'CDLFODMOGMQAWXDURDXTUAOO9BFESHYGZLBUWIIHPTLNZCUNHZAAXSUPUIBW'
-            'IRLOVKCVWJSWEKRJQZUVRDZGZRNANUNCSGANCJWVHMZMVNJVUAZNFZKDAIVV'
-            'LSMIM9SVGUHYECTGGIXTAMXXO9FIXUMQFZCGRQWAOWJPBTXNNQIRSTZEEAJV'
-            'FSXWTHWBQJCWQNYYMHSPCYRA99ITVILYJPMFGOGOUOZUVABK9HMGABSORCVD'
-            'FNGLMPJ9NFKBWCZMFPIWEAGRWPRNLLG9VYUUVLCTEWKGWQIRIJKERZWC9LVR'
-            'XJEXNHBNUGEGGLMWGERKYFB9YEZCLXLKKMCGLRKQOGASDOUDYEDJLMV9BHPG'
-            'GCXQIUVUOFFXKEIIINLVWLRYHHLKXPLSTWKIKNEJWEDFQQFXQVEHGRCIJC9T'
-            'GVQNPPKGCFGPJNWSCPQZDDSIGAVZEIVYJDVPUOCTEMKTZFGXNGPQCOIBD9MX'
-            'YTHJTX'
-        )
+    curl = Curl()
+    curl.absorb(trits, offset=243, length=486)
+    curl.absorb(trits, offset=0, length=243)
+    trits_out = []
+    curl.squeeze(trits_out)
 
+    trits_out = TryteString.from_trits(trits_out)
 
-        d = [0] * 243
-        trits = TryteString(inp).as_trits()
-        curl = Curl()
+    # noinspection SpellCheckingInspection
+    self.assertEqual(
+      trits_out,
 
-        for i in range(6):
-            curl.reset()
-            curl.absorb(trits, i * 243, (i + 1) * 243)
-            curl.squeeze(trits, i * 243)
+      'ZWNF9YOCAKC9CXQFYZDKXSSAZOCAZLEVEB9OZDJQ'
+      'GWEULHUDY9RAWAT9GIUXTTUSYJEGNGQDVJCGTQLN9',
+    )
 
-        curl.reset()
-        curl.absorb(trits)
-        curl.squeeze(d)
+  def test_squeeze_offset(self):
+    """
+    Passing an ``offset`` argument to :py:meth:`Curl.squeeze`.
 
-        trits_out = TryteString.from_trits(d)
+    Example use case:
+    https://github.com/iotaledger/iri/blob/v1.4.1.6/src/main/java/com/iota/iri/hash/ISS.java#L83
+    """
+    # noinspection SpellCheckingInspection
+    input_ = (
+      'CDLFODMOGMQAWXDURDXTUAOO9BFESHYGZLBUWIIHPTLNZCUNHZAAXSUPUIBW'
+      'IRLOVKCVWJSWEKRJQZUVRDZGZRNANUNCSGANCJWVHMZMVNJVUAZNFZKDAIVV'
+      'LSMIM9SVGUHYECTGGIXTAMXXO9FIXUMQFZCGRQWAOWJPBTXNNQIRSTZEEAJV'
+      'FSXWTHWBQJCWQNYYMHSPCYRA99ITVILYJPMFGOGOUOZUVABK9HMGABSORCVD'
+      'FNGLMPJ9NFKBWCZMFPIWEAGRWPRNLLG9VYUUVLCTEWKGWQIRIJKERZWC9LVR'
+      'XJEXNHBNUGEGGLMWGERKYFB9YEZCLXLKKMCGLRKQOGASDOUDYEDJLMV9BHPG'
+      'GCXQIUVUOFFXKEIIINLVWLRYHHLKXPLSTWKIKNEJWEDFQQFXQVEHGRCIJC9T'
+      'GVQNPPKGCFGPJNWSCPQZDDSIGAVZEIVYJDVPUOCTEMKTZFGXNGPQCOIBD9MX'
+      'YTHJTX'
+    )
 
-        self.assertEqual(
-            trits_out,
-            'TAWDGNSEAD9ZRGBBVRVEKQYYVDOKHYQ9KEIYJKFT'
-            'BQEYZDWZVMRFJQQGTMPHBZOGPIJCCVWLZVDKLAQVI')
+    trits = TryteString(input_).as_trits()
+    curl = Curl()
 
-    def test_squeeze_with_486_length_should_work(self):
-        """
-        Test squeeze with 486 length should work as well, no one use this
-        in real situation
-        """
-        inp = (
-          'EMIDYNHBWMBCXVDEFOFWINXTERALUKYYPPHKP9JJ'
-          'FGJEIUY9MUDVNFZHMMWZUYUSWAIOWEVTHNWMHANBH'
-        )
+    trits_out = [0] * 243
+    for i in range(6):
+      curl.reset()
+      curl.absorb(trits, i * 243, (i + 1) * 243)
+      curl.squeeze(trits, i * 243)
 
-        trits = TryteString(inp).as_trits()
+    curl.reset()
+    curl.absorb(trits)
+    curl.squeeze(trits_out)
 
-        curl = Curl()
-        curl.absorb(trits)
-        trits_out = []
-        curl.squeeze(trits_out, length=486)
+    trits_out = TryteString.from_trits(trits_out)
 
-        trits_out = TryteString.from_trits(trits_out)
+    # noinspection SpellCheckingInspection
+    self.assertEqual(
+      trits_out,
 
-        self.assertEqual(
-            trits_out,
-            'AQBOPUMJMGVHFOXSMUAGZNACKUTISDPBSILMRAGIG'
-            'RXXS9JJTLIKZUW9BCJWKSTFBDSBLNVEEGVGAMSSMQ'
-            'GSJWCCFQRHWKTSMVPWWCEGOMCNWFYWDZBEDBLXIFB'
-            'HOTCKUMCANLSXXTNKSYNBMOSDDEYFTDOYIKDRJM')
+      'TAWDGNSEAD9ZRGBBVRVEKQYYVDOKHYQ9KEIYJKFT'
+      'BQEYZDWZVMRFJQQGTMPHBZOGPIJCCVWLZVDKLAQVI',
+    )
+
+  def test_squeeze_multiple_hashes(self):
+    """
+    Squeezing more than 1 hash from the sponge.
+    """
+    # noinspection SpellCheckingInspection
+    input_ = (
+      'EMIDYNHBWMBCXVDEFOFWINXTERALUKYYPPHKP9JJ'
+      'FGJEIUY9MUDVNFZHMMWZUYUSWAIOWEVTHNWMHANBH'
+    )
+
+    trits = TryteString(input_).as_trits()
+
+    curl = Curl()
+    curl.absorb(trits)
+    trits_out = []
+    curl.squeeze(trits_out, length=486)
+
+    trits_out = TryteString.from_trits(trits_out)
+
+    # noinspection SpellCheckingInspection
+    self.assertEqual(
+      trits_out,
+
+      'AQBOPUMJMGVHFOXSMUAGZNACKUTISDPBSILMRAGIG'
+      'RXXS9JJTLIKZUW9BCJWKSTFBDSBLNVEEGVGAMSSMQ'
+      'GSJWCCFQRHWKTSMVPWWCEGOMCNWFYWDZBEDBLXIFB'
+      'HOTCKUMCANLSXXTNKSYNBMOSDDEYFTDOYIKDRJM',
+    )

--- a/test/crypto/pycurl_test.py
+++ b/test/crypto/pycurl_test.py
@@ -1,0 +1,165 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, \
+  unicode_literals
+
+from unittest import TestCase
+
+from iota import TryteString
+from iota.crypto import Curl
+
+
+class TestCurl(TestCase):
+    """
+    This is the test case for CURL-P hash function used in IOTA
+    """
+    def test_correct_first(self):
+        """Test the inp tryte string will get the correct output"""
+        inp = (
+          'EMIDYNHBWMBCXVDEFOFWINXTERALUKYYPPHKP9JJ'
+          'FGJEIUY9MUDVNFZHMMWZUYUSWAIOWEVTHNWMHANBH'
+        )
+
+        trits = TryteString(inp).as_trits()
+
+        curl = Curl()
+        curl.absorb(trits)
+        trits_out = []
+        curl.squeeze(trits_out)
+
+        trits_out = TryteString.from_trits(trits_out)
+
+        self.assertEqual(
+            trits_out,
+            'AQBOPUMJMGVHFOXSMUAGZNACKUTISDPBSILMRAGIG'
+            'RXXS9JJTLIKZUW9BCJWKSTFBDSBLNVEEGVGAMSSM')
+
+    def test_input_length_greater_than_243(self):
+        """Test input trytes length greater than hash length should work"""
+        inp = (
+          'G9JYBOMPUXHYHKSNRNMMSSZCSHOFYOYNZRSZMAAYWDYEIMVVOGKPJB'
+          'VBM9TDPULSFUNMTVXRKFIDOHUXXVYDLFSZYZTWQYTE9SPYYWYTXJYQ'
+          '9IFGYOLZXWZBKWZN9QOOTBQMWMUBLEWUEEASRHRTNIQWJQNDWRYLCA'
+        )
+
+        trits = TryteString(inp).as_trits()
+
+        curl = Curl()
+        curl.absorb(trits)
+        trits_out = []
+        curl.squeeze(trits_out)
+
+        trits_out = TryteString.from_trits(trits_out)
+
+        self.assertEqual(
+            trits_out,
+            'RWCBOLRFANOAYQWXXTFQJYQFAUTEEBSZWTIRSSDR'
+            'EYGCNFRLHQVDZXYXSJKCQFQLJMMRHYAZKRRLQZDKR')
+
+    def test_input_without_offset(self):
+        """Test input without offset should work"""
+        inp = (
+          'G9JYBOMPUXHYHKSNRNMMSSZCSHOFYOYNZRSZMAAYWDYEIMVVOGKPJB'
+          'VBM9TDPULSFUNMTVXRKFIDOHUXXVYDLFSZYZTWQYTE9SPYYWYTXJYQ'
+          '9IFGYOLZXWZBKWZN9QOOTBQMWMUBLEWUEEASRHRTNIQWJQNDWRYLCA'
+        )
+
+        trits = TryteString(inp).as_trits()
+
+        curl = Curl()
+        curl.absorb(trits, 0, length=486)
+        curl.absorb(trits, 0, length=243)
+        trits_out = []
+        curl.squeeze(trits_out)
+
+        trits_out = TryteString.from_trits(trits_out)
+
+        self.assertEqual(
+            trits_out,
+            'OTYHXEXJLCSMEY9LYCC9ASJXMORTLAYQEHRS9DAH'
+            '9NR9DXLXYDGOVOBEL9LWRITLWPHPYPZDKXVPAPKUA')
+
+    def test_input_with_offset(self):
+        """Test input with offset should work"""
+        inp = (
+          'G9JYBOMPUXHYHKSNRNMMSSZCSHOFYOYNZRSZMAAYWDYEIMVVOGKPJB'
+          'VBM9TDPULSFUNMTVXRKFIDOHUXXVYDLFSZYZTWQYTE9SPYYWYTXJYQ'
+          '9IFGYOLZXWZBKWZN9QOOTBQMWMUBLEWUEEASRHRTNIQWJQNDWRYLCA'
+        )
+
+        trits = TryteString(inp).as_trits()
+
+        curl = Curl()
+        curl.absorb(trits, 243, length=486)
+        curl.absorb(trits, 0, length=243)
+        trits_out = []
+        curl.squeeze(trits_out)
+
+        trits_out = TryteString.from_trits(trits_out)
+
+        self.assertEqual(
+            trits_out,
+            'ZWNF9YOCAKC9CXQFYZDKXSSAZOCAZLEVEB9OZDJQG'
+            'WEULHUDY9RAWAT9GIUXTTUSYJEGNGQDVJCGTQLN9')
+
+    def test_squeeze_with_offset(self):
+        """Test squeeze with offset, this only used in ISS
+        GitHub IRI ISS: https://github.com/iotaledger/iri/blob/dev/src/main/java/com/iota/iri/hash/ISS.java#L83
+        """
+        inp = (
+            'CDLFODMOGMQAWXDURDXTUAOO9BFESHYGZLBUWIIHPTLNZCUNHZAAXSUPUIBW'
+            'IRLOVKCVWJSWEKRJQZUVRDZGZRNANUNCSGANCJWVHMZMVNJVUAZNFZKDAIVV'
+            'LSMIM9SVGUHYECTGGIXTAMXXO9FIXUMQFZCGRQWAOWJPBTXNNQIRSTZEEAJV'
+            'FSXWTHWBQJCWQNYYMHSPCYRA99ITVILYJPMFGOGOUOZUVABK9HMGABSORCVD'
+            'FNGLMPJ9NFKBWCZMFPIWEAGRWPRNLLG9VYUUVLCTEWKGWQIRIJKERZWC9LVR'
+            'XJEXNHBNUGEGGLMWGERKYFB9YEZCLXLKKMCGLRKQOGASDOUDYEDJLMV9BHPG'
+            'GCXQIUVUOFFXKEIIINLVWLRYHHLKXPLSTWKIKNEJWEDFQQFXQVEHGRCIJC9T'
+            'GVQNPPKGCFGPJNWSCPQZDDSIGAVZEIVYJDVPUOCTEMKTZFGXNGPQCOIBD9MX'
+            'YTHJTX'
+        )
+
+
+        d = [0] * 243
+        trits = TryteString(inp).as_trits()
+        curl = Curl()
+
+        for i in range(6):
+            curl.reset()
+            curl.absorb(trits, i * 243, (i + 1) * 243)
+            curl.squeeze(trits, i * 243)
+
+        curl.reset()
+        curl.absorb(trits)
+        curl.squeeze(d)
+
+        trits_out = TryteString.from_trits(d)
+
+        self.assertEqual(
+            trits_out,
+            'TAWDGNSEAD9ZRGBBVRVEKQYYVDOKHYQ9KEIYJKFT'
+            'BQEYZDWZVMRFJQQGTMPHBZOGPIJCCVWLZVDKLAQVI')
+
+    def test_squeeze_with_486_length_should_work(self):
+        """
+        Test squeeze with 486 length should work as well, no one use this
+        in real situation
+        """
+        inp = (
+          'EMIDYNHBWMBCXVDEFOFWINXTERALUKYYPPHKP9JJ'
+          'FGJEIUY9MUDVNFZHMMWZUYUSWAIOWEVTHNWMHANBH'
+        )
+
+        trits = TryteString(inp).as_trits()
+
+        curl = Curl()
+        curl.absorb(trits)
+        trits_out = []
+        curl.squeeze(trits_out, length=486)
+
+        trits_out = TryteString.from_trits(trits_out)
+
+        self.assertEqual(
+            trits_out,
+            'AQBOPUMJMGVHFOXSMUAGZNACKUTISDPBSILMRAGIG'
+            'RXXS9JJTLIKZUW9BCJWKSTFBDSBLNVEEGVGAMSSMQ'
+            'GSJWCCFQRHWKTSMVPWWCEGOMCNWFYWDZBEDBLXIFB'
+            'HOTCKUMCANLSXXTNKSYNBMOSDDEYFTDOYIKDRJM')

--- a/test/filters_test.py
+++ b/test/filters_test.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function, \
 import filters as f
 from filters.test import BaseFilterTestCase
 
-from iota import Address, TryteString, TransactionHash
+from iota import Address, TransactionHash, TryteString
 from iota.filters import AddressNoChecksum, GeneratedAddress, NodeUri, Trytes
 
 
@@ -70,19 +70,30 @@ class NodeUriTestCase(BaseFilterTestCase):
     """
     self.assertFilterPasses(None)
 
-  def test_pass_uri(self):
-    """The incoming value is a valid URI."""
+  def test_pass_udp(self):
+    """
+    The incoming value is a valid UDP URI.
+    """
     self.assertFilterPasses('udp://localhost:14265/node')
+
+  def test_pass_tcp(self):
+    """
+    The incoming value is a valid TCP URI.
+
+    https://github.com/iotaledger/iota.lib.py/issues/111
+    """
+    self.assertFilterPasses('tcp://localhost:14265/node')
 
   def test_fail_not_a_uri(self):
     """
     The incoming value is not a URI.
 
-    Note: Internally, the filter uses `resolve_adapter`, which has its
-      own unit tests.  We won't duplicate them here; a simple smoke
-      check should suffice.
+    Note: Internally, the filter uses ``resolve_adapter``, which has its
+    own unit tests.  We won't duplicate them here; a simple smoke
+    check should suffice.
 
-    :py:class:`test.adapter_test.ResolveAdapterTestCase`
+    References:
+      - :py:class:`test.adapter_test.ResolveAdapterTestCase`
     """
     self.assertFilterErrors(
       'not a valid uri',
@@ -92,7 +103,7 @@ class NodeUriTestCase(BaseFilterTestCase):
   def test_fail_bytes(self):
     """
     To ensure consistent behavior in Python 2 and 3, bytes are not
-      accepted.
+    accepted.
     """
     self.assertFilterErrors(
       b'udp://localhost:14265/node',
@@ -100,7 +111,9 @@ class NodeUriTestCase(BaseFilterTestCase):
     )
 
   def test_fail_wrong_type(self):
-    """The incoming value is not a string."""
+    """
+    The incoming value is not a string.
+    """
     self.assertFilterErrors(
       # Use ``FilterRepeater(NodeUri)`` to validate a sequence of URIs.
       ['udp://localhost:14265/node'],
@@ -121,7 +134,9 @@ class TrytesTestCase(BaseFilterTestCase):
     self.assertFilterPasses(None)
 
   def test_pass_ascii(self):
-    """The incoming value is ASCII."""
+    """
+    The incoming value is ASCII.
+    """
     trytes = b'RBTC9D9DCDQAEASBYBCCKBFA'
 
     filter_ = self._filter(trytes)
@@ -130,7 +145,9 @@ class TrytesTestCase(BaseFilterTestCase):
     self.assertIsInstance(filter_.cleaned_data, TryteString)
 
   def test_pass_bytearray(self):
-    """The incoming value is a bytearray."""
+    """
+    The incoming value is a bytearray.
+    """
     trytes = bytearray(b'RBTC9D9DCDQAEASBYBCCKBFA')
 
     filter_ = self._filter(trytes)
@@ -139,7 +156,9 @@ class TrytesTestCase(BaseFilterTestCase):
     self.assertIsInstance(filter_.cleaned_data, TryteString)
 
   def test_pass_tryte_string(self):
-    """The incoming value is a TryteString."""
+    """
+    The incoming value is a TryteString.
+    """
     trytes = TryteString(b'RBTC9D9DCDQAEASBYBCCKBFA')
 
     filter_ = self._filter(trytes)
@@ -148,7 +167,9 @@ class TrytesTestCase(BaseFilterTestCase):
     self.assertIsInstance(filter_.cleaned_data, TryteString)
 
   def test_pass_alternate_result_type(self):
-    """Configuring the filter to return a specific type."""
+    """
+    Configuring the filter to return a specific type.
+    """
     input_trytes = b'RBTC9D9DCDQAEASBYBCCKBFA'
 
     result_trytes = (
@@ -165,11 +186,12 @@ class TrytesTestCase(BaseFilterTestCase):
     """
     The incoming value contains an invalid character.
 
-    Note: Internally, the filter uses `TryteString`, which has its own
-      unit tests.  We won't duplicate them here; a simple smoke check
-      should suffice.
+    Note: Internally, the filter uses :py:class:`TryteString`, which has
+    its own unit tests.  We won't duplicate them here; a simple smoke
+    check should suffice.
 
-    :ref:`test.types_test.TryteStringTestCase`
+    References:
+      - :py:class:`test.types_test.TryteStringTestCase`
     """
     self.assertFilterErrors(
       # Everyone knows there's no such thing as "8"!
@@ -180,7 +202,7 @@ class TrytesTestCase(BaseFilterTestCase):
   def test_fail_alternate_result_type(self):
     """
     The incoming value is a valid tryte sequence, but the filter is
-      configured for a specific type with stricter validation.
+    configured for a specific type with stricter validation.
     """
     trytes = (
       # Ooh, just a little bit too long there.
@@ -194,10 +216,12 @@ class TrytesTestCase(BaseFilterTestCase):
     )
 
   def test_fail_wrong_type(self):
-    """The incoming value has an incompatible type."""
+    """
+    The incoming value has an incompatible type.
+    """
     self.assertFilterErrors(
       # Use ``FilterRepeater(Trytes)`` to validate a sequence of tryte
-      #   representations.
+      # representations.
       [TryteString(b'RBTC9D9DCDQAEASBYBCCKBFA')],
       [f.Type.CODE_WRONG_TYPE],
     )
@@ -212,9 +236,6 @@ class AddressNoChecksumTestCase(BaseFilterTestCase):
     super(AddressNoChecksumTestCase, self).setUp()
 
     # Define some addresses that we can reuse between tests
-    """
-    Incoming value is not an :py:class:`Address` instance.
-    """
     self.tryte1 = (
       b'TESTVALUE9DONTUSEINPRODUCTION99999FBFFTG'
       b'QFWEHEL9KCAFXBJBXGE9HID9XCOHFIDABHDG9AHDR'
@@ -226,7 +247,7 @@ class AddressNoChecksumTestCase(BaseFilterTestCase):
 
   def test_pass_no_checksum_addy(self):
     """
-    Incoming value is tryte in address form or Address object
+    Incoming value is tryte in address form or Address object.
     """
     self.assertFilterPasses(self.tryte1)
     self.assertFilterPasses(self.address)
@@ -234,14 +255,15 @@ class AddressNoChecksumTestCase(BaseFilterTestCase):
   def test_pass_with_checksum_addy(self):
     """
     After passing through the filter an address with a checksum should
-    return the address without
+    return the address without.
     """
     self.assertFilterPasses(self.address_with_checksum, self.address)
 
   def test_fail_with_bad_checksum_addy(self):
     """
-    If they've got a bad checksum in their address we should probably tell
-    them so they don't wonder why something works in one place and not another
+    If they've got a bad checksum in their address we should probably
+    tell them, so they don't wonder why something works in one place and
+    not another.
     """
     self.assertFilterErrors(
       self.address_with_bad_checksum,

--- a/test/transaction/base_test.py
+++ b/test/transaction/base_test.py
@@ -4,8 +4,8 @@ from __future__ import absolute_import, division, print_function, \
 
 from unittest import TestCase
 
-from iota import Address, Bundle, BundleHash, Fragment, Hash, \
-  Tag, Transaction, TransactionHash, TransactionTrytes, TryteString, Nonce
+from iota import Address, Bundle, BundleHash, Fragment, Hash, Nonce, Tag, \
+  Transaction, TransactionHash, TransactionTrytes
 
 
 class BundleTestCase(TestCase):
@@ -74,7 +74,7 @@ class BundleTestCase(TestCase):
       # fragment.
       Transaction(
         signature_message_fragment =
-          Fragment.from_string('Hello, world!'),
+          Fragment.from_unicode('Hello, world!'),
 
         address =
           Address(
@@ -207,7 +207,7 @@ class BundleTestCase(TestCase):
         # Make the signature look like a message, so we can verify that
         # the Bundle skips it correctly.
         signature_message_fragment =
-          Fragment.from_string('This is a signature, not a message!'),
+          Fragment.from_unicode('This is a signature, not a message!'),
 
         address =
           Address(
@@ -237,7 +237,7 @@ class BundleTestCase(TestCase):
         # Make the signature look like a message, so we can verify that
         # the Bundle skips it correctly.
         signature_message_fragment =
-          Fragment.from_string('This is a signature, not a message!'),
+          Fragment.from_unicode('This is a signature, not a message!'),
 
         address =
           Address(
@@ -267,7 +267,7 @@ class BundleTestCase(TestCase):
         # It's unusual for a change transaction to have a message, but
         # half the fun of unit tests is designing unusual scenarios!
         signature_message_fragment =
-          Fragment.from_string('I can haz change?'),
+          Fragment.from_unicode('I can haz change?'),
 
         address =
           Address(
@@ -534,7 +534,7 @@ class TransactionTestCase(TestCase):
         b'QZUIJDFPTTCTKBJRHAITVSKUCUEMD9M9SQJ999999'
       ),
     )
-    
+
     self.assertEqual(transaction.tag, Tag(b'999999999999999999999999999'))
     self.assertEqual(transaction.attachment_timestamp,1480690413)
     self.assertEqual(transaction.attachment_timestamp_lower_bound,1480690413)
@@ -642,12 +642,12 @@ class TransactionTestCase(TestCase):
           b'TKORV9IKTJZQUBQAWTKBKZ9NEZHBFIMCLV9TTNJN'
           b'QZUIJDFPTTCTKBJRHAITVSKUCUEMD9M9SQJ999999'
         ),
-        
+
       tag                               = Tag(b'999999999999999999999999999'),
       attachment_timestamp              = 1480690413,
       attachment_timestamp_lower_bound  = 1480690413,
       attachment_timestamp_upper_bound  = 1480690413,
-      
+
 
       nonce =
         Nonce(

--- a/test/transaction/creation_test.py
+++ b/test/transaction/creation_test.py
@@ -115,7 +115,7 @@ class ProposedBundleTestCase(TestCase):
           b'D9YBTH9EMFKF9CAHJIAIKDBEPAMH99DEN9DAJETGN'
         ),
 
-      message = TryteString.from_string('Hello, IOTA!'),
+      message = TryteString.from_unicode('Hello, IOTA!'),
       value   = 42,
     ))
 
@@ -134,13 +134,13 @@ class ProposedBundleTestCase(TestCase):
       b'HCFIUGLBSCKELC9IYENFPHCEWHIDCHCGGEH9OFZBN'
     )
 
-    tag = Tag.from_string('H2G2')
+    tag = Tag.from_unicode('H2G2')
 
     self.bundle.add_transaction(ProposedTransaction(
       address = address,
       tag     = tag,
 
-      message = TryteString.from_string(
+      message = TryteString.from_unicode(
         '''
 "Good morning," said Deep Thought at last.
 "Er... Good morning, O Deep Thought," said Loonquawl nervously.


### PR DESCRIPTION
# PyOTA v2.0.4

**⚠️ This release contains a few changes that may be backwards-incompatible, depending on how your application is configured.  Check the Backwards-Incompatible Changes section for more information! ⚠️**

## Backwards-Incompatible Changes
### Renamed CLI Command
The `iota-cli` command has been renamed to `pyota-cli`, to avoid conflicts with the [cli-app](https://github.com/iotaledger/cli-app/blob/v1.0.8/package.json#L31) project.

If PyOTA is already installed, the `iota-cli` command will continue to work (the `pyota-cli` command will be installed alongside it).  However, if you install PyOTA into a new virtualenv, it will **not** install the `iota-cli` command, only `pyota-cli`!

### Deprecated Methods
The following methods now emit a `DeprecationWarning` when invoked.  Depending on how your application is configured, these warnings may be converted into exceptions.

* `TryteString.as_bytes()` (use `TryteString.encode()` instead).
* `TryteString.as_string()` (use `TryteString.decode()` instead).
* `TryteString.from_string()` (use `TryteString.from_unicode()` instead).

To resolve the `DeprecationWarning`, replace usages of the deprecated methods with the replacement versions as noted above.

**Tip: After making this change, your application will no longer be compatible with PyOTA <= 2.0.4; it is recommended that you also add `pyota >= 2.0.4` to your project's `setup.py` or `requirements.txt` file!**

If your application does not use any of the methods listed above, no action is required.

## Changelog
* (#121) Added `is_promotable` and `promote_transaction` API methods (thanks [@scottbelden]!).
* (#38) Added `is_reattachable` API method (thanks [@jinnerbichler]!).
* (#122) Rename `iota-cli` command to prevent conflict with `cli-app` project (thanks [@plenarius]!).
* (#129) Added `authentication` argument to `HttpAdapter` (thanks [@HerrMuellerluedenscheid]!).
* (#105) Added `timeout` argument to `HttpAdapter` (thanks [@jinnerbichler]!).
* (#111) `add_neighbor` and `remove_neighbor` now also accept URIs that start with `tcp://` (thanks [@danielfaust] for reporting!).
* (#92) Added `offset` and `length` arguments to PyCurl methods (thanks [@mlouielu]!).
* (#90) Renamed the following methods:
    * `TryteString.as_bytes()` => `TryteString.encode()`
    * `TryteString.as_string()` => `TryteString.decode()`
    * `TryteString.from_string()` => `TryteString.from_unicode()`
* (#130) Fixed incorrect type in `get_tips` response (thanks [@za-uz] for reporting!)
* (#120) Fixed references to "standard" API in the documentation (thanks [@rpitonak]!).
* Added `helpers` namespace to `Iota` (thanks [@scottbelden]!).
* Added missing fields in transaction documentation (thanks [@GalRogozinski]!).
* Made `examples/send_transfer.py` easier to read (thanks [@maeck70]!).
* Added new setuptools extra "`test-runner`", to install [detox](https://pypi.python.org/pypi/detox).
    * Added more information about running unit tests to `README.rst`.
* Added metadata check to the build process and fixed invalid syntax in `README.rst`.
    * This should also fix rendering issues on [PyOTA's PyPI page](https://pypi.python.org/pypi/PyOTA).
* Fixed incorrect type hint for `find_transaction_objects`.
* Changed link in `README.rst` from Slack to Discord.

## Special Thanks
Thank you to everyone who helped make this release a success!

* [@danielfaust]
* [@GalRogozinski]
* [@HerrMuellerluedenscheid]
* [@jinnerbichler]
* [@maeck70]
* [@mlouielu]
* [@plenarius]
* [@rpitonak]
* [@scottbelden]
* [@za-uz]

And to the entire PyOTA community!  Seriously, you guys rock!


  [@danielfaust]: https://github.com/danielfaust
  [@GalRogozinski]: https://github.com/GalRogozinski
  [@HerrMuellerluedenscheid]: https://github.com/HerrMuellerluedenscheid
  [@jinnerbichler]: https://github.com/jinnerbichler
  [@maeck70]: https://github.com/maeck70
  [@mlouielu]: https://github.com/mlouielu
  [@plenarius]: https://github.com/plenarius
  [@rpitonak]: https://github.com/rpitonak
  [@scottbelden]: https://github.com/scottbelden
  [@za-uz]: https://github.com/za-uz
