### PR TITLE
Accept hashes argument to find_transaction_objects

### DIFF
--- a/iota/commands/extended/utils.py
+++ b/iota/commands/extended/utils.py
@@ -22,9 +22,13 @@ def find_transaction_objects(adapter, **kwargs):
     Finds transactions matching the specified criteria, fetches the
     corresponding trytes and converts them into Transaction objects.
     """
-    ft_response = FindTransactionsCommand(adapter)(**kwargs)
 
-    hashes = ft_response['hashes']
+    if 'hashes' in kwargs:
+        hashes = kwargs['hashes']
+    else:
+        ft_response = FindTransactionsCommand(adapter)(**kwargs)
+
+        hashes = ft_response['hashes']
 
     if hashes:
       gt_response = GetTrytesCommand(adapter)(hashes=hashes)


### PR DESCRIPTION
Sometimes, the user may already have a list of hashes, in which case we can bypass find_transactions. 