### PR TITLE
Fixed Array Bounds for Fragment

### DIFF
--- a/iota/crypto/types.py
+++ b/iota/crypto/types.py
@@ -189,8 +189,8 @@ class PrivateKey(TryteString):
       sponge.absorb(key_fragment)
       sponge.squeeze(hash_trits)
 
-      fragment_start  = i * FRAGMENT_LENGTH
-      fragment_end    = fragment_start + FRAGMENT_LENGTH
+      fragment_start  = i * HASH_LENGTH
+      fragment_end    = fragment_start + HASH_LENGTH
 
       digest[fragment_start:fragment_end] = hash_trits
 

--- a/iota/crypto/types.py
+++ b/iota/crypto/types.py
@@ -189,10 +189,10 @@ class PrivateKey(TryteString):
       sponge.absorb(key_fragment)
       sponge.squeeze(hash_trits)
 
-      fragment_start  = i * HASH_LENGTH
-      fragment_end    = fragment_start + HASH_LENGTH
+      fragment_hash_start  = i * HASH_LENGTH
+      fragment_hash_end    = fragment_hash_start + HASH_LENGTH
 
-      digest[fragment_start:fragment_end] = hash_trits
+      digest[fragment_hash_start:fragment_hash_end] = hash_trits
 
     return Digest(TryteString.from_trits(digest), self.key_index)
 


### PR DESCRIPTION
Changed array bound from FRAGMENT_LENGTH (which is 2187 in trytes) to HASH_LENGTH (which is 243 in trits).