### PR TITLE
Removing transaction symbols from package namespace (2)

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -265,7 +265,7 @@ Bundle
 
 .. code:: python
 
-    from iota import Bundle
+    from iota.transaction.base import Bundle
 
     bundle = Bundle.from_tryte_strings([
       b'GYPRVHBEZOOFXSHQBLCYW9ICTCISLHDBNMMVYD9JJHQMPQCTIQAQTJNNNJ9IDXLRCC...',

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -101,7 +101,9 @@ Transaction
 
 .. code:: python
 
-    from iota import Address, ProposedTransaction, Tag, Transaction
+    from iota import Address, Tag
+    from iota.transaction.base import Transaction
+    from iota.transaction.creation import ProposedTransaction
 
     txn_1 =\
       Transaction.from_tryte_string(
@@ -293,7 +295,8 @@ ProposedBundle
 
 .. code:: python
 
-    from iota import Address, ProposedBundle, ProposedTransaction
+    from iota import Address
+    from iota.transaction.creation import ProposedBundle, ProposedTransaction
     from iota.crypto.signing import KeyGenerator
 
     bundle = ProposedBundle()

--- a/examples/mam_js_send.py
+++ b/examples/mam_js_send.py
@@ -12,11 +12,12 @@ from typing import List, Optional, Text
 import filters as f
 from six import binary_type, text_type
 
-from iota import Bundle, Iota, TransactionTrytes
+from iota import Bundle, Iota
 from iota.bin import IotaCommandLineApp
 from iota.crypto.addresses import AddressGenerator
 from iota.filters import Trytes
 from iota.json import JsonEncoder
+from iota.transaction.types import TransactionTrytes
 
 
 class IotaMamExample(IotaCommandLineApp):

--- a/examples/mam_js_send.py
+++ b/examples/mam_js_send.py
@@ -12,11 +12,12 @@ from typing import List, Optional, Text
 import filters as f
 from six import binary_type, text_type
 
-from iota import Bundle, Iota
+from iota import Iota
 from iota.bin import IotaCommandLineApp
 from iota.crypto.addresses import AddressGenerator
 from iota.filters import Trytes
 from iota.json import JsonEncoder
+from iota.transaction.base import Bundle
 from iota.transaction.types import TransactionTrytes
 
 

--- a/examples/multisig.py
+++ b/examples/multisig.py
@@ -15,11 +15,14 @@ from __future__ import absolute_import, division, print_function, \
 
 from typing import List
 
-from iota import Address, Bundle, BundleValidator, ProposedTransaction, Tag, \
-    TransactionTrytes, TryteString
+from iota import Address, Tag, TryteString
 from iota.crypto.types import Digest, PrivateKey, Seed
 from iota.multisig import MultisigIota
 from iota.multisig.types import MultisigAddress
+from iota.transaction.base import Bundle
+from iota.transaction.creation import ProposedTransaction
+from iota.transaction.types import TransactionTrytes
+from iota.transaction.validator import BundleValidator
 
 """
 Step 1:  Each participant generates one or more digests that will be

--- a/examples/routingwrapper_pow.py
+++ b/examples/routingwrapper_pow.py
@@ -7,8 +7,9 @@ References:
 
 - https://pyota.readthedocs.io/en/develop/adapters.html#routingwrapper
 """
-from iota import Address, Iota, ProposedTransaction, Tag, TryteString
+from iota import Address, Iota, Tag, TryteString
 from iota.adapter.wrappers import RoutingWrapper
+from iota.transaction.creation import ProposedTransaction
 
 # Send PoW requests to local node.
 # All other requests go to light wallet node.

--- a/examples/sandbox.py
+++ b/examples/sandbox.py
@@ -2,8 +2,9 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-from iota import Address, Iota, ProposedTransaction, Tag, TryteString
+from iota import Address, Iota, Tag, TryteString
 from iota.adapter.sandbox import SandboxAdapter
+from iota.transaction.creation import ProposedTransaction
 
 # Create the API client.
 api = Iota(

--- a/examples/send_transfer.py
+++ b/examples/send_transfer.py
@@ -2,19 +2,20 @@
 """
 Example script that shows how to use PyOTA to send a transfer to an address.
 """
+
 from argparse import ArgumentParser
+from six import text_type
 from sys import argv
 
+from address_generator import get_seed, output_seed
 from iota import (
   __version__,
   Address,
   Iota,
-  ProposedTransaction,
   Tag,
   TryteString,
 )
-from six import text_type
-from address_generator import get_seed, output_seed
+from iota.transaction.creation import ProposedTransaction
 
 
 def main(address, depth, message, tag, uri, value):

--- a/iota/__init__.py
+++ b/iota/__init__.py
@@ -33,7 +33,6 @@ from .codecs import *
 # Make some imports accessible from the top level of the package.
 # Note that order is important, to prevent circular imports.
 from .types import *
-from .transaction import *
 from .adapter import *
 from .api import *
 from .trits import *

--- a/iota/api.py
+++ b/iota/api.py
@@ -2,18 +2,19 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
+from six import with_metaclass
 from typing import Dict, Iterable, Optional, Text
 
-from six import with_metaclass
-
-from iota import AdapterSpec, Address, BundleHash, ProposedTransaction, Tag, \
-    TransactionHash, TransactionTrytes, TryteString, TrytesCompatible
+from iota import AdapterSpec, Address, Tag, TryteString, TrytesCompatible
 from iota.adapter import BaseAdapter, resolve_adapter
 from iota.commands import BaseCommand, CustomCommand, core, \
     discover_commands, extended
 from iota.commands.extended.helpers import Helpers
 from iota.crypto.addresses import AddressGenerator
 from iota.crypto.types import Seed
+from iota.transaction.creation import ProposedTransaction
+from iota.transaction.types import BundleHash, TransactionHash, \
+    TransactionTrytes
 
 __all__ = [
     'InvalidCommand',

--- a/iota/commands/core/attach_to_tangle.py
+++ b/iota/commands/core/attach_to_tangle.py
@@ -4,8 +4,8 @@ from __future__ import absolute_import, division, print_function, \
 
 import filters as f
 
-from iota import TransactionHash, TransactionTrytes
 from iota.commands import FilterCommand, RequestFilter, ResponseFilter
+from iota.transaction.types import TransactionHash, TransactionTrytes
 from iota.filters import Trytes
 
 __all__ = [

--- a/iota/commands/core/broadcast_transactions.py
+++ b/iota/commands/core/broadcast_transactions.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import, division, print_function, \
 
 import filters as f
 
-from iota import TransactionTrytes
 from iota.commands import FilterCommand, RequestFilter
 from iota.filters import Trytes
+from iota.transaction.types import TransactionTrytes
 
 __all__ = [
     'BroadcastTransactionsCommand',

--- a/iota/commands/core/check_consistency.py
+++ b/iota/commands/core/check_consistency.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import, division, print_function, \
 
 import filters as f
 
-from iota import TransactionHash
 from iota.commands import FilterCommand, RequestFilter
 from iota.filters import Trytes
+from iota.transaction.types import TransactionHash
 
 __all__ = [
     'CheckConsistencyCommand',

--- a/iota/commands/core/find_transactions.py
+++ b/iota/commands/core/find_transactions.py
@@ -5,9 +5,10 @@ from __future__ import absolute_import, division, print_function, \
 import filters as f
 from six import iteritems
 
-from iota import BundleHash, Tag, TransactionHash
+from iota import Tag
 from iota.commands import FilterCommand, RequestFilter, ResponseFilter
 from iota.filters import AddressNoChecksum, Trytes
+from iota.transaction.types import BundleHash, TransactionHash
 
 __all__ = [
     'FindTransactionsCommand',

--- a/iota/commands/core/get_inclusion_states.py
+++ b/iota/commands/core/get_inclusion_states.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import, division, print_function, \
 
 import filters as f
 
-from iota import TransactionHash
 from iota.commands import FilterCommand, RequestFilter
 from iota.filters import Trytes
+from iota.transaction.types import TransactionHash
 
 __all__ = [
     'GetInclusionStatesCommand',

--- a/iota/commands/core/get_node_info.py
+++ b/iota/commands/core/get_node_info.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import, division, print_function, \
 
 import filters as f
 
-from iota import TransactionHash
 from iota.commands import FilterCommand, RequestFilter, ResponseFilter
 from iota.filters import Trytes
+from iota.transaction.types import TransactionHash
 
 __all__ = [
     'GetNodeInfoCommand',

--- a/iota/commands/core/get_transactions_to_approve.py
+++ b/iota/commands/core/get_transactions_to_approve.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import, division, print_function, \
 
 import filters as f
 
-from iota import TransactionHash
 from iota.commands import FilterCommand, RequestFilter, ResponseFilter
 from iota.filters import Trytes
+from iota.transaction.types import TransactionHash
 
 __all__ = [
     'GetTransactionsToApproveCommand',

--- a/iota/commands/core/get_trytes.py
+++ b/iota/commands/core/get_trytes.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import, division, print_function, \
 
 import filters as f
 
-from iota import TransactionHash
 from iota.commands import FilterCommand, RequestFilter, ResponseFilter
 from iota.filters import Trytes
+from iota.transaction.types import TransactionHash
 
 __all__ = [
     'GetTrytesCommand',

--- a/iota/commands/core/store_transactions.py
+++ b/iota/commands/core/store_transactions.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import, division, print_function, \
 
 import filters as f
 
-from iota import TransactionTrytes
 from iota.commands import FilterCommand, RequestFilter
 from iota.filters import Trytes
+from iota.transaction.types import TransactionTrytes
 
 __all__ = [
     'StoreTransactionsCommand',

--- a/iota/commands/extended/get_account_data.py
+++ b/iota/commands/extended/get_account_data.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 
 import filters as f
 
-from iota import Address, TransactionHash
+from iota import Address
 from iota.commands import FilterCommand, RequestFilter
 from iota.commands.core.find_transactions import FindTransactionsCommand
 from iota.commands.core.get_balances import GetBalancesCommand
@@ -16,6 +16,7 @@ from iota.commands.extended.utils import get_bundles_from_transaction_hashes, \
 from iota.crypto.addresses import AddressGenerator
 from iota.crypto.types import Seed
 from iota.filters import Trytes, SecurityLevel
+from iota.transaction.types import TransactionHash
 
 __all__ = [
     'GetAccountDataCommand',

--- a/iota/commands/extended/get_bundles.py
+++ b/iota/commands/extended/get_bundles.py
@@ -6,12 +6,13 @@ from typing import List, Optional
 
 import filters as f
 
-from iota import BadApiResponse, Bundle, BundleHash, Transaction, \
-    TransactionHash, TryteString
+from iota import BadApiResponse, TryteString
 from iota.commands import FilterCommand, RequestFilter
 from iota.commands.core.get_trytes import GetTrytesCommand
 from iota.exceptions import with_context
 from iota.filters import Trytes
+from iota.transaction.base import Bundle, Transaction
+from iota.transaction.types import BundleHash, TransactionHash
 from iota.transaction.validator import BundleValidator
 
 __all__ = [

--- a/iota/commands/extended/get_latest_inclusion.py
+++ b/iota/commands/extended/get_latest_inclusion.py
@@ -6,11 +6,11 @@ from typing import List
 
 import filters as f
 
-from iota import TransactionHash
 from iota.commands import FilterCommand, RequestFilter
 from iota.commands.core.get_inclusion_states import GetInclusionStatesCommand
 from iota.commands.core.get_node_info import GetNodeInfoCommand
 from iota.filters import Trytes
+from iota.transaction.types import TransactionHash
 
 __all__ = [
     'GetLatestInclusionCommand',

--- a/iota/commands/extended/prepare_transfer.py
+++ b/iota/commands/extended/prepare_transfer.py
@@ -6,8 +6,7 @@ from typing import List, Optional
 
 import filters as f
 
-from iota import Address, BadApiResponse, ProposedBundle, \
-    ProposedTransaction
+from iota import Address, BadApiResponse
 from iota.commands import FilterCommand, RequestFilter
 from iota.commands.core.get_balances import GetBalancesCommand
 from iota.commands.extended.get_inputs import GetInputsCommand
@@ -16,6 +15,7 @@ from iota.crypto.signing import KeyGenerator
 from iota.crypto.types import Seed
 from iota.exceptions import with_context
 from iota.filters import GeneratedAddress, SecurityLevel, Trytes
+from iota.transaction.creation import ProposedBundle, ProposedTransaction
 
 __all__ = [
     'PrepareTransferCommand',

--- a/iota/commands/extended/promote_transaction.py
+++ b/iota/commands/extended/promote_transaction.py
@@ -4,11 +4,13 @@ from __future__ import absolute_import, division, print_function, \
 
 import filters as f
 
-from iota import Address, BadApiResponse, ProposedTransaction, TransactionHash
+from iota import Address, BadApiResponse
 from iota.commands import FilterCommand, RequestFilter
 from iota.commands.core.check_consistency import CheckConsistencyCommand
 from iota.commands.extended.send_transfer import SendTransferCommand
 from iota.filters import Trytes
+from iota.transaction.creation import ProposedTransaction
+from iota.transaction.types import TransactionHash
 
 __all__ = [
     'PromoteTransactionCommand',

--- a/iota/commands/extended/replay_bundle.py
+++ b/iota/commands/extended/replay_bundle.py
@@ -4,11 +4,12 @@ from __future__ import absolute_import, division, print_function, \
 
 import filters as f
 
-from iota import Bundle, TransactionHash
 from iota.commands import FilterCommand, RequestFilter
 from iota.commands.extended.get_bundles import GetBundlesCommand
 from iota.commands.extended.send_trytes import SendTrytesCommand
 from iota.filters import Trytes
+from iota.transaction.base import Bundle
+from iota.transaction.types import TransactionHash
 
 __all__ = [
     'ReplayBundleCommand',

--- a/iota/commands/extended/send_transfer.py
+++ b/iota/commands/extended/send_transfer.py
@@ -6,12 +6,15 @@ from typing import List, Optional
 
 import filters as f
 
-from iota import Address, Bundle, ProposedTransaction, TransactionHash
+from iota import Address
 from iota.commands import FilterCommand, RequestFilter
 from iota.commands.extended.prepare_transfer import PrepareTransferCommand
 from iota.commands.extended.send_trytes import SendTrytesCommand
 from iota.crypto.types import Seed
 from iota.filters import SecurityLevel, Trytes
+from iota.transaction.base import Bundle
+from iota.transaction.creation import ProposedTransaction
+from iota.transaction.types import TransactionHash
 
 __all__ = [
     'SendTransferCommand',

--- a/iota/commands/extended/send_trytes.py
+++ b/iota/commands/extended/send_trytes.py
@@ -6,13 +6,14 @@ from typing import List, Optional
 
 import filters as f
 
-from iota import TransactionHash, TransactionTrytes, TryteString
+from iota import TryteString
 from iota.commands import FilterCommand, RequestFilter
 from iota.commands.core.attach_to_tangle import AttachToTangleCommand
 from iota.commands.core.get_transactions_to_approve import \
     GetTransactionsToApproveCommand
 from iota.commands.extended.broadcast_and_store import BroadcastAndStoreCommand
 from iota.filters import Trytes
+from iota.transaction.types import TransactionTrytes, TransactionHash
 
 __all__ = [
     'SendTrytesCommand',

--- a/iota/commands/extended/utils.py
+++ b/iota/commands/extended/utils.py
@@ -4,8 +4,7 @@ from __future__ import absolute_import, division, print_function, \
 
 from typing import Generator, Iterable, List, Optional, Tuple
 
-from iota import Address, Bundle, Transaction, \
-    TransactionHash
+from iota import Address
 from iota.adapter import BaseAdapter
 from iota.commands.core.find_transactions import FindTransactionsCommand
 from iota.commands.core.get_trytes import GetTrytesCommand
@@ -14,6 +13,8 @@ from iota.commands.extended.get_latest_inclusion import \
     GetLatestInclusionCommand
 from iota.crypto.addresses import AddressGenerator
 from iota.crypto.types import Seed
+from iota.transaction.base import Bundle, Transaction
+from iota.transaction.types import TransactionHash
 
 
 def find_transaction_objects(adapter, **kwargs):

--- a/iota/multisig/api.py
+++ b/iota/multisig/api.py
@@ -4,12 +4,13 @@ from __future__ import absolute_import, division, print_function, \
 
 from typing import Iterable, Optional
 
-from iota import Address, Iota, ProposedTransaction
+from iota import Address, Iota
 from iota.commands import discover_commands
 from iota.crypto.addresses import AddressGenerator
 from iota.crypto.types import Digest
 from iota.multisig import commands
 from iota.multisig.types import MultisigAddress
+from iota.transaction.creation import ProposedTransaction
 
 __all__ = [
     'MultisigIota',

--- a/iota/multisig/commands/prepare_multisig_transfer.py
+++ b/iota/multisig/commands/prepare_multisig_transfer.py
@@ -6,13 +6,14 @@ from typing import List, Optional
 
 import filters as f
 
-from iota import Address, ProposedTransaction
+from iota import Address
 from iota.commands import FilterCommand, RequestFilter
 from iota.commands.core import GetBalancesCommand
 from iota.exceptions import with_context
 from iota.filters import Trytes
 from iota.multisig.transaction import ProposedMultisigBundle
 from iota.multisig.types import MultisigAddress
+from iota.transaction.creation import ProposedTransaction
 
 __all__ = [
     'PrepareMultisigTransferCommand',

--- a/iota/multisig/transaction.py
+++ b/iota/multisig/transaction.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import, division, print_function, \
 
 from typing import Iterable
 
-from iota import ProposedBundle
 from iota.exceptions import with_context
 from iota.multisig.types import MultisigAddress
+from iota.transaction.creation import ProposedBundle
 
 __all__ = [
   'ProposedMultisigBundle',

--- a/iota/transaction/__init__.py
+++ b/iota/transaction/__init__.py
@@ -1,11 +1,3 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
-# Import symbols to package namespace, for backwards-compatibility with
-# PyOTA 1.1.x.
-from .base import *
-from .creation import *
-from .types import *
-from .utils import *
-from .validator import *
+  unicode_literals

--- a/test/commands/core/attach_to_tangle_test.py
+++ b/test/commands/core/attach_to_tangle_test.py
@@ -2,15 +2,16 @@
 from __future__ import absolute_import, division, print_function, \
   unicode_literals
 
+from six import binary_type, text_type
 from unittest import TestCase
 
 import filters as f
 from filters.test import BaseFilterTestCase
-from iota import Iota, TransactionHash, TransactionTrytes, TryteString
+from iota import Iota, TryteString
 from iota.adapter import MockAdapter
 from iota.commands.core.attach_to_tangle import AttachToTangleCommand
 from iota.filters import Trytes
-from six import binary_type, text_type
+from iota.transaction.types import TransactionHash, TransactionTrytes
 
 
 class AttachToTangleRequestFilterTestCase(BaseFilterTestCase):

--- a/test/commands/core/broadcast_transactions_test.py
+++ b/test/commands/core/broadcast_transactions_test.py
@@ -8,11 +8,12 @@ import filters as f
 from filters.test import BaseFilterTestCase
 from six import binary_type, text_type
 
-from iota import Iota, TransactionTrytes, TryteString
+from iota import Iota, TryteString
 from iota.adapter import MockAdapter
 from iota.commands.core.broadcast_transactions import \
   BroadcastTransactionsCommand
 from iota.filters import Trytes
+from iota.transaction.types import TransactionTrytes
 
 
 class BroadcastTransactionsRequestFilterTestCase(BaseFilterTestCase):

--- a/test/commands/core/check_consistency_test.py
+++ b/test/commands/core/check_consistency_test.py
@@ -7,10 +7,11 @@ from unittest import TestCase
 import filters as f
 from filters.test import BaseFilterTestCase
 
-from iota import Iota, TransactionHash, TryteString
+from iota import Iota, TryteString
 from iota.adapter import MockAdapter
 from iota.commands.core.check_consistency import CheckConsistencyCommand
 from iota.filters import Trytes
+from iota.transaction.types import TransactionHash
 
 
 class CheckConsistencyRequestFilterTestCase(BaseFilterTestCase):

--- a/test/commands/core/find_transactions_test.py
+++ b/test/commands/core/find_transactions_test.py
@@ -8,11 +8,12 @@ import filters as f
 from filters.test import BaseFilterTestCase
 from six import text_type
 
-from iota import Address, Iota, Tag, BundleHash, TransactionHash, TryteString
+from iota import Address, Iota, Tag, TryteString
 from iota.adapter import MockAdapter
 from iota.commands.core.find_transactions import FindTransactionsCommand, \
   FindTransactionsRequestFilter
 from iota.filters import Trytes
+from iota.transaction.types import BundleHash, TransactionHash
 
 
 class FindTransactionsRequestFilterTestCase(BaseFilterTestCase):

--- a/test/commands/core/get_inclusion_states_test.py
+++ b/test/commands/core/get_inclusion_states_test.py
@@ -6,11 +6,11 @@ from unittest import TestCase
 
 import filters as f
 from filters.test import BaseFilterTestCase
-from iota import Iota, TransactionHash, TryteString
+from iota import Iota, TryteString
 from iota.adapter import MockAdapter
 from iota.commands.core.get_inclusion_states import GetInclusionStatesCommand
 from iota.filters import Trytes
-from six import binary_type, text_type
+from iota.transaction.types import TransactionHash
 
 
 class GetInclusionStatesRequestFilterTestCase(BaseFilterTestCase):

--- a/test/commands/core/get_node_info_test.py
+++ b/test/commands/core/get_node_info_test.py
@@ -6,9 +6,10 @@ from unittest import TestCase
 
 import filters as f
 from filters.test import BaseFilterTestCase
-from iota import Iota, TransactionHash
+from iota import Iota
 from iota.adapter import MockAdapter
 from iota.commands.core.get_node_info import GetNodeInfoCommand
+from iota.transaction.types import TransactionHash
 
 
 class GetNodeInfoRequestFilterTestCase(BaseFilterTestCase):

--- a/test/commands/core/get_transactions_to_approve_test.py
+++ b/test/commands/core/get_transactions_to_approve_test.py
@@ -6,11 +6,12 @@ from unittest import TestCase
 
 import filters as f
 from filters.test import BaseFilterTestCase
-from iota import Iota, TransactionHash
+from iota import Iota
 from iota.adapter import MockAdapter
 from iota.commands.core.get_transactions_to_approve import \
   GetTransactionsToApproveCommand
 from iota.filters import Trytes
+from iota.transaction.types import TransactionHash
 
 
 class GetTransactionsToApproveRequestFilterTestCase(BaseFilterTestCase):

--- a/test/commands/core/get_trytes_test.py
+++ b/test/commands/core/get_trytes_test.py
@@ -7,10 +7,11 @@ from unittest import TestCase
 import filters as f
 from filters.test import BaseFilterTestCase
 
-from iota import Iota, TransactionHash, TryteString
+from iota import Iota, TryteString
 from iota.adapter import MockAdapter
 from iota.commands.core.get_trytes import GetTrytesCommand
 from iota.filters import Trytes
+from iota.transaction.types import TransactionHash
 
 
 class GetTrytesRequestFilterTestCase(BaseFilterTestCase):

--- a/test/commands/core/store_transactions_test.py
+++ b/test/commands/core/store_transactions_test.py
@@ -8,10 +8,11 @@ import filters as f
 from filters.test import BaseFilterTestCase
 from six import text_type
 
-from iota import Iota, TransactionTrytes, TryteString
+from iota import Iota, TryteString
 from iota.adapter import MockAdapter
 from iota.commands.core.store_transactions import StoreTransactionsCommand
 from iota.filters import Trytes
+from iota.transaction.types import TransactionTrytes
 
 
 class StoreTransactionsRequestFilterTestCase(BaseFilterTestCase):

--- a/test/commands/extended/broadcast_and_store_test.py
+++ b/test/commands/extended/broadcast_and_store_test.py
@@ -6,9 +6,10 @@ from unittest import TestCase
 
 from six import text_type
 
-from iota import Iota, TransactionTrytes
+from iota import Iota
 from iota.adapter import MockAdapter
 from iota.commands.extended.broadcast_and_store import BroadcastAndStoreCommand
+from iota.transaction.types import TransactionTrytes
 
 
 class BroadcastAndStoreCommandTestCase(TestCase):

--- a/test/commands/extended/get_account_data_test.py
+++ b/test/commands/extended/get_account_data_test.py
@@ -8,12 +8,14 @@ import filters as f
 from filters.test import BaseFilterTestCase
 from six import binary_type
 
-from iota import Address, Bundle, Iota, TransactionHash
+from iota import Address, Iota
 from iota.adapter import MockAdapter
 from iota.commands.extended.get_account_data import GetAccountDataCommand, \
   GetAccountDataRequestFilter
 from iota.crypto.types import Seed
 from iota.filters import Trytes
+from iota.transaction.base import Bundle
+from iota.transaction.types import TransactionHash
 from test import mock
 
 

--- a/test/commands/extended/get_bundles_test.py
+++ b/test/commands/extended/get_bundles_test.py
@@ -7,11 +7,13 @@ from unittest import TestCase
 import filters as f
 from filters.test import BaseFilterTestCase
 
-from iota import Address, BadApiResponse, Bundle, BundleHash, Fragment, Hash, \
-  Iota, Tag, Transaction, TransactionHash, TransactionTrytes, Nonce
+from iota import Address, BadApiResponse, Iota, Tag
 from iota.adapter import MockAdapter
 from iota.commands.extended.get_bundles import GetBundlesCommand
 from iota.filters import Trytes
+from iota.transaction.base import Bundle, Transaction
+from iota.transaction.types import BundleHash, Fragment, \
+  Nonce, TransactionHash, TransactionTrytes
 
 
 class GetBundlesRequestFilterTestCase(BaseFilterTestCase):

--- a/test/commands/extended/get_inputs_test.py
+++ b/test/commands/extended/get_inputs_test.py
@@ -7,12 +7,13 @@ from unittest import TestCase
 import filters as f
 from filters.test import BaseFilterTestCase
 
-from iota import Address, BadApiResponse, Iota, TransactionHash
+from iota import Address, BadApiResponse, Iota
 from iota.adapter import MockAdapter
 from iota.commands.extended.get_inputs import GetInputsCommand, GetInputsRequestFilter
 from iota.crypto.addresses import AddressGenerator
 from iota.crypto.types import Seed
 from iota.filters import Trytes
+from iota.transaction.types import TransactionHash
 from test import mock
 
 

--- a/test/commands/extended/get_latest_inclusion_test.py
+++ b/test/commands/extended/get_latest_inclusion_test.py
@@ -7,11 +7,12 @@ from unittest import TestCase
 import filters as f
 from filters.test import BaseFilterTestCase
 
-from iota import Iota, TransactionHash, TryteString
+from iota import Iota, TryteString
 from iota.adapter import MockAdapter
 from iota.commands.extended.get_latest_inclusion import \
   GetLatestInclusionCommand
 from iota.filters import Trytes
+from iota.transaction.types import TransactionHash
 
 
 class GetLatestInclusionRequestFilterTestCase(BaseFilterTestCase):

--- a/test/commands/extended/get_transfers_test.py
+++ b/test/commands/extended/get_transfers_test.py
@@ -8,12 +8,13 @@ import filters as f
 from filters.test import BaseFilterTestCase
 from six import binary_type
 
-from iota import Address, Bundle, Iota, Tag, Transaction, TryteString
+from iota import Address, Iota, Tag, TryteString
 from iota.adapter import MockAdapter
 from iota.commands.extended.get_transfers import GetTransfersCommand, \
   GetTransfersRequestFilter
 from iota.crypto.types import Seed
 from iota.filters import Trytes
+from iota.transaction.base import Bundle, Transaction
 from test import mock
 
 

--- a/test/commands/extended/helpers_test.py
+++ b/test/commands/extended/helpers_test.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, \
 
 from unittest import TestCase
 
-from iota import Iota, TransactionHash
+from iota import Iota
 from iota.adapter import MockAdapter
 
 

--- a/test/commands/extended/prepare_transfer_test.py
+++ b/test/commands/extended/prepare_transfer_test.py
@@ -8,13 +8,15 @@ import filters as f
 from filters.test import BaseFilterTestCase
 from six import binary_type, iterkeys
 
-from iota import Address, BadApiResponse, Iota, ProposedTransaction, Tag, \
-  TryteString, Transaction, TransactionHash
+from iota import Address, BadApiResponse, Iota, Tag, TryteString
 from iota.adapter import MockAdapter
 from iota.commands.extended.prepare_transfer import PrepareTransferCommand
 from iota.crypto.addresses import AddressGenerator
 from iota.crypto.types import Seed
 from iota.filters import GeneratedAddress, Trytes
+from iota.transaction.base import Transaction
+from iota.transaction.creation import ProposedTransaction
+from iota.transaction.types import TransactionHash
 from test import mock
 
 

--- a/test/commands/extended/promote_transaction_test.py
+++ b/test/commands/extended/promote_transaction_test.py
@@ -8,10 +8,12 @@ import filters as f
 from filters.test import BaseFilterTestCase
 from six import binary_type
 
-from iota import Bundle, Iota, TransactionHash, TransactionTrytes, BadApiResponse
+from iota import Iota, BadApiResponse
 from iota.adapter import MockAdapter
 from iota.commands.extended.promote_transaction import PromoteTransactionCommand
 from iota.filters import Trytes
+from iota.transaction.base import Bundle
+from iota.transaction.types import TransactionHash, TransactionTrytes
 from test import mock
 
 

--- a/test/commands/extended/replay_bundle_test.py
+++ b/test/commands/extended/replay_bundle_test.py
@@ -8,11 +8,13 @@ import filters as f
 from filters.test import BaseFilterTestCase
 from six import binary_type
 
-from iota import Address, Bundle, BundleHash, Fragment, Iota, Nonce, Tag, \
-  Transaction, TransactionHash
+from iota import Address, Iota, Tag
 from iota.adapter import MockAdapter
 from iota.commands.extended.replay_bundle import ReplayBundleCommand
 from iota.filters import Trytes
+from iota.transaction.base import Bundle, Transaction
+from iota.transaction.types import BundleHash, Fragment, \
+  Nonce, TransactionHash
 from test import mock
 
 

--- a/test/commands/extended/send_transfer_test.py
+++ b/test/commands/extended/send_transfer_test.py
@@ -8,13 +8,15 @@ import filters as f
 from filters.test import BaseFilterTestCase
 from six import binary_type
 
-from iota import Address, Bundle, Iota, ProposedTransaction, TransactionHash, \
-  TransactionTrytes, TryteString
+from iota import Address, Iota, TryteString
 from iota.adapter import MockAdapter
 from iota.commands.extended.send_transfer import SendTransferCommand
 from iota.crypto.addresses import AddressGenerator
 from iota.crypto.types import Seed
 from iota.filters import Trytes
+from iota.transaction.base import Bundle
+from iota.transaction.creation import ProposedTransaction
+from iota.transaction.types import TransactionHash, TransactionTrytes
 from test import mock
 
 

--- a/test/commands/extended/send_trytes_test.py
+++ b/test/commands/extended/send_trytes_test.py
@@ -8,10 +8,11 @@ import filters as f
 from filters.test import BaseFilterTestCase
 from six import binary_type, text_type
 
-from iota import Iota, TransactionTrytes, TryteString, TransactionHash
+from iota import Iota, TryteString
 from iota.adapter import MockAdapter
 from iota.commands.extended.send_trytes import SendTrytesCommand
 from iota.filters import Trytes
+from iota.transaction.types import TransactionHash, TransactionTrytes
 
 
 class SendTrytesRequestFilterTestCase(BaseFilterTestCase):

--- a/test/filters_test.py
+++ b/test/filters_test.py
@@ -5,8 +5,9 @@ from __future__ import absolute_import, division, print_function, \
 import filters as f
 from filters.test import BaseFilterTestCase
 
-from iota import Address, TransactionHash, TryteString
+from iota import Address, TryteString
 from iota.filters import AddressNoChecksum, GeneratedAddress, NodeUri, Trytes
+from iota.transaction.types import TransactionHash
 
 
 class GeneratedAddressTestCase(BaseFilterTestCase):

--- a/test/multisig/commands/prepare_multisig_transfer_test.py
+++ b/test/multisig/commands/prepare_multisig_transfer_test.py
@@ -7,13 +7,16 @@ from unittest import TestCase
 import filters as f
 from filters.test import BaseFilterTestCase
 
-from iota import Address, Bundle, Fragment, ProposedTransaction
+from iota import Address
 from iota.adapter import MockAdapter
 from iota.commands.core import GetBalancesCommand
 from iota.crypto.types import Digest
 from iota.multisig import MultisigIota
 from iota.multisig.commands import PrepareMultisigTransferCommand
 from iota.multisig.types import MultisigAddress
+from iota.transaction.base import Bundle
+from iota.transaction.creation import ProposedTransaction
+from iota.transaction.types import Fragment
 
 
 class PrepareMultisigTransferRequestFilterTestCase(BaseFilterTestCase):

--- a/test/multisig/transaction_test.py
+++ b/test/multisig/transaction_test.py
@@ -4,10 +4,11 @@ from __future__ import absolute_import, division, print_function, \
 
 from unittest import TestCase
 
-from iota import Address, ProposedTransaction
+from iota import Address
 from iota.crypto.types import Digest
 from iota.multisig.transaction import ProposedMultisigBundle
 from iota.multisig.types import MultisigAddress
+from iota.transaction.creation import ProposedTransaction
 
 
 class ProposedMultisigBundleTestCase(TestCase):

--- a/test/transaction/base_test.py
+++ b/test/transaction/base_test.py
@@ -4,8 +4,10 @@ from __future__ import absolute_import, division, print_function, \
 
 from unittest import TestCase
 
-from iota import Address, Bundle, BundleHash, Fragment, Hash, Nonce, Tag, \
-  Transaction, TransactionHash, TransactionTrytes
+from iota import Address, Hash, Tag
+from iota.transaction.base import Bundle, Transaction
+from iota.transaction.types import BundleHash, Fragment, Nonce, \
+  TransactionHash, TransactionTrytes
 
 
 class BundleTestCase(TestCase):

--- a/test/transaction/creation_test.py
+++ b/test/transaction/creation_test.py
@@ -4,11 +4,11 @@ from __future__ import absolute_import, division, print_function, \
 
 from unittest import TestCase
 
-from iota import Address, Fragment, ProposedBundle, ProposedTransaction, Tag, \
-  TryteString
+from iota import Address, Tag, TryteString
 from iota.crypto.signing import KeyGenerator
 from iota.crypto.types import Seed
-from iota.transaction.types import BundleHash
+from iota.transaction.types import BundleHash, Fragment
+from iota.transaction.creation import ProposedBundle, ProposedTransaction
 
 
 class ProposedBundleTestCase(TestCase):

--- a/test/transaction/types_test.py
+++ b/test/transaction/types_test.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 
 from six import binary_type
 
-from iota import TransactionHash
+from iota.transaction.types import TransactionHash
 
 
 class TransactionHashTestCase(TestCase):

--- a/test/transaction/utils_test.py
+++ b/test/transaction/utils_test.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, \
 
 from unittest import TestCase
 
-from iota import convert_value_to_standard_unit
+from iota.transaction.utils import convert_value_to_standard_unit
 
 
 class ConvertValueToStandardUnitTestCase(TestCase):

--- a/test/transaction/validator_test.py
+++ b/test/transaction/validator_test.py
@@ -4,7 +4,10 @@ from __future__ import absolute_import, division, print_function, \
 
 from unittest import TestCase
 
-from iota import Address, Bundle, BundleHash, BundleValidator, TransactionTrytes
+from iota import Address
+from iota.transaction.base import Bundle
+from iota.transaction.types import BundleHash, TransactionTrytes
+from iota.transaction.validator import BundleValidator
 
 
 class BundleValidatorTestCase(TestCase):


### PR DESCRIPTION
Fix #185. (I've created another branch with commit that carries changes from my initial commit and another commit that carries all the changes that I've missed).